### PR TITLE
Add basic tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Crowfather
+
+Crowfather is a small Go service that exposes HTTP endpoints for interacting with GroupMe and OpenAI.  The server is configured using environment variables and uses the [gin](https://github.com/gin-gonic/gin) framework for routing.
+
+## Structure
+
+```
+internal/
+  config       - loading configuration from environment variables
+  groupme      - send messages to the GroupMe API
+  handlers/
+      message_handler   - process incoming GroupMe messages
+      meltdown_handler  - simple text handler
+      test_handler      - simple text handler
+  open_ai      - wrapper around the OpenAI API
+  router       - HTTP routes and middleware
+  main.go      - program entry point
+```
+
+## Endpoints
+
+* `GET /ping` – health check returning `pong`.
+* `POST /message` – receives a GroupMe webhook payload and responds using OpenAI.
+* `POST /meltdown` – send a single message to OpenAI.
+* `POST /test` – test endpoint protected by the `API_KEY` header or query parameter.
+
+## Configuration
+
+The service relies on several environment variables:
+
+```
+OPENAI_API_KEY          OpenAI API key
+GROUPME_BOT_ID          GroupMe bot identifier
+GROUPME_BOT_TOKEN       authentication token for GroupMe
+GROUPME_ASSISTANT_ID    OpenAI assistant ID for group messages
+MELTDOWN_ASSISTANT_ID   OpenAI assistant ID for meltdown messages
+TEST_ASSISTANT_ID       OpenAI assistant ID for test messages
+API_KEY                 simple API key used by the test route
+```
+
+Set these variables before running the server with `go run ./internal`.
+
+## Running Tests
+
+Unit tests cover the configuration loader and the GroupMe client.  Execute them with:
+
+```
+go test ./internal/config ./internal/groupme
+```
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestLoadConfigSuccess(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "openai")
+	t.Setenv("GROUPME_BOT_ID", "bot")
+	t.Setenv("GROUPME_BOT_TOKEN", "token")
+	t.Setenv("API_KEY", "secret")
+	t.Setenv("GROUPME_ASSISTANT_ID", "gmaid")
+	t.Setenv("MELTDOWN_ASSISTANT_ID", "meltdown")
+	t.Setenv("TEST_ASSISTANT_ID", "test")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if cfg.OpenAI.APIKey != "openai" {
+		t.Errorf("unexpected openai api key: %s", cfg.OpenAI.APIKey)
+	}
+	if cfg.GroupMe.BotID != "bot" {
+		t.Errorf("unexpected bot id: %s", cfg.GroupMe.BotID)
+	}
+	if cfg.Auth.APIKey != "secret" {
+		t.Errorf("unexpected api key: %s", cfg.Auth.APIKey)
+	}
+}
+
+func TestLoadOpenAIConfigMissing(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	if _, err := loadOpenAIConfig(); err == nil {
+		t.Fatalf("expected error when OPENAI_API_KEY missing")
+	}
+}

--- a/internal/groupme/groupme_test.go
+++ b/internal/groupme/groupme_test.go
@@ -1,0 +1,81 @@
+package groupme
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"crowfather/internal/config"
+)
+
+func newService() *GroupMeService {
+	return &GroupMeService{Config: &config.GroupMeConfig{BotID: "bot", Token: "token", Host: "example.com", Path: "/v3/bots/post"}, Client: http.DefaultClient}
+}
+
+func TestBuildURL(t *testing.T) {
+	svc := newService()
+	u := svc.buildUrl()
+	if u.Scheme != "https" || u.Host != "example.com" || u.Path != "/v3/bots/post" {
+		t.Errorf("unexpected url: %v", u)
+	}
+}
+
+func TestBuildPayload(t *testing.T) {
+	svc := newService()
+	payload, err := svc.buildPayload(Message{Name: "Bob"}, "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req MessageSendRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if req.BotId != "bot" || req.Text != "@Bob hi" {
+		t.Errorf("unexpected payload: %+v", req)
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	svc := newService()
+	req := svc.buildRequest(context.Background(), []byte("data"))
+	if req.Method != "POST" {
+		t.Errorf("expected POST got %s", req.Method)
+	}
+	if req.Header.Get("Authorization") != "token" {
+		t.Errorf("missing auth header")
+	}
+}
+
+func TestSendRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	svc := &GroupMeService{Client: server.Client(), Config: &config.GroupMeConfig{}}
+	u, _ := url.Parse(server.URL)
+	req := &http.Request{Method: "POST", URL: u}
+	ok, err := svc.sendRequest(req)
+	if err != nil || !ok {
+		t.Fatalf("expected success, got %v %v", ok, err)
+	}
+}
+
+func TestSendRequestFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("fail"))
+	}))
+	defer server.Close()
+
+	svc := &GroupMeService{Client: server.Client(), Config: &config.GroupMeConfig{}}
+	u, _ := url.Parse(server.URL)
+	req := &http.Request{Method: "POST", URL: u}
+	ok, err := svc.sendRequest(req)
+	if err == nil || ok {
+		t.Fatalf("expected failure")
+	}
+}


### PR DESCRIPTION
## Summary
- add README describing project structure and configuration
- add unit tests for configuration loader
- add unit tests for GroupMe client helpers

## Testing
- `go test -v ./internal/config ./internal/groupme`

------
https://chatgpt.com/codex/tasks/task_e_6848ab5abeb48329bb570303b2bc3735