### PR TITLE
Add postgres persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ GROUPME_ASSISTANT_ID    OpenAI assistant ID for group messages
 MELTDOWN_ASSISTANT_ID   OpenAI assistant ID for meltdown messages
 TEST_ASSISTANT_ID       OpenAI assistant ID for test messages
 API_KEY                 simple API key used by the test route
+DB_USER                 database username
+DB_PASS                 database password
+DB_HOST                 database host
+DB_NAME                 database name
 ```
 
 Set these variables before running the server with `go run ./internal`.
 
 ## Running Tests
 
-Unit tests cover the configuration loader and the GroupMe client.  Execute them with:
+Unit tests cover the configuration loader, the GroupMe client and the database layer. Execute them with:
 
 ```
-go test ./internal/config ./internal/groupme
+go test ./...
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@ go 1.23.0
 toolchain go1.24.2
 
 require (
-	github.com/gin-gonic/gin v1.10.0
-	github.com/openai/openai-go v0.1.0-beta.10
+        github.com/DATA-DOG/go-sqlmock v1.5.0
+        github.com/gin-gonic/gin v1.10.0
+        github.com/lib/pq v1.10.9
+        github.com/openai/openai-go v0.1.0-beta.10
 )
 
 require (

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,23 +4,71 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+
+	_ "github.com/lib/pq"
 )
 
 type DatabaseService struct {
 	db *sql.DB
 }
 
-func ConnectDb() *DatabaseService {
-	connStr := fmt.Sprintf("user=%s password=%s host=%s dbname=%s", os.Getenv("DB_USER"), os.Getenv("DB_PASS"), os.Getenv("HOST"), os.Getenv("DB_NAME"))
+func ConnectDb() (*DatabaseService, error) {
+	connStr := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=disable", os.Getenv("DB_USER"), os.Getenv("DB_PASS"), os.Getenv("DB_HOST"), os.Getenv("DB_NAME"))
 	db, err := sql.Open("postgres", connStr)
 
 	if err != nil {
-		fmt.Println("Failed to connect to database instance %v", err)
+		return nil, fmt.Errorf("failed to connect to database instance %v", err)
 	}
 
 	if err := db.Ping(); err != nil {
-		fmt.Println("Failed to connect to database instance %v", err)
+		return nil, fmt.Errorf("failed to connect to database instance %v", err)
+	}
+	svc := &DatabaseService{db: db}
+	if err := svc.init(); err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func (d *DatabaseService) init() error {
+	createThreads := `CREATE TABLE IF NOT EXISTS threads (
+        context_id TEXT PRIMARY KEY,
+        thread_id TEXT NOT NULL
+    );`
+	if _, err := d.db.Exec(createThreads); err != nil {
+		return err
 	}
 
-	return &DatabaseService{db: db}
+	createMessages := `CREATE TABLE IF NOT EXISTS messages (
+        id SERIAL PRIMARY KEY,
+        thread_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        content TEXT NOT NULL
+    );`
+	if _, err := d.db.Exec(createMessages); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *DatabaseService) SaveThread(contextID, threadID string) error {
+	_, err := d.db.Exec(`INSERT INTO threads (context_id, thread_id) VALUES ($1,$2)
+        ON CONFLICT (context_id) DO UPDATE SET thread_id = EXCLUDED.thread_id`, contextID, threadID)
+	return err
+}
+
+func (d *DatabaseService) GetThread(contextID string) (string, error) {
+	var threadID string
+	err := d.db.QueryRow(`SELECT thread_id FROM threads WHERE context_id=$1`, contextID).Scan(&threadID)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("thread not found")
+	}
+	return threadID, err
+}
+
+func (d *DatabaseService) SaveMessage(threadID, role, messageID, content string) error {
+	_, err := d.db.Exec(`INSERT INTO messages (thread_id, role, message_id, content) VALUES ($1,$2,$3,$4)`,
+		threadID, role, messageID, content)
+	return err
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,0 +1,66 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestSaveThread(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	svc := &DatabaseService{db: db}
+	mock.ExpectExec("INSERT INTO threads").WithArgs("ctx", "tid").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := svc.SaveThread("ctx", "tid"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestGetThread(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	svc := &DatabaseService{db: db}
+	rows := sqlmock.NewRows([]string{"thread_id"}).AddRow("tid")
+	mock.ExpectQuery("SELECT thread_id FROM threads").WithArgs("ctx").WillReturnRows(rows)
+
+	id, err := svc.GetThread("ctx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "tid" {
+		t.Errorf("expected tid got %s", id)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestSaveMessage(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	svc := &DatabaseService{db: db}
+	mock.ExpectExec("INSERT INTO messages").WithArgs("tid", "user", "mid", "hello").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	if err := svc.SaveMessage("tid", "user", "mid", "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crowfather/internal/config"
+	"crowfather/internal/database"
 	"crowfather/internal/groupme"
 	"crowfather/internal/open_ai"
 	"crowfather/internal/router"
@@ -10,7 +11,11 @@ import (
 )
 
 func main() {
-	//db := database.ConnectDb();
+	db, err := database.ConnectDb()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	config, err := config.LoadConfig()
 
 	if err != nil {
@@ -18,7 +23,7 @@ func main() {
 		return
 	}
 
-	oai := open_ai.NewOpenAIService(config.OpenAI)
+	oai := open_ai.NewOpenAIService(config.OpenAI, db)
 	gms := groupme.NewGroupMeService(config.GroupMe)
 	router, err := router.NewRouter(oai, gms, config)
 


### PR DESCRIPTION
## Summary
- implement Postgres database service for saving threads and messages
- store conversation data via OpenAI service
- connect to the database in `main`
- add unit tests for the DB layer
- document database configuration and updated test instructions

## Testing
- `go test ./internal/database` *(fails: missing go.sum entry for github.com/lib/pq)*

------
https://chatgpt.com/codex/tasks/task_e_6862d64347cc8329b8d9ce3c4cc623f6