### PR TITLE
Fix three bugs in OpenAI service and message handler, resolve vet errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ toolchain go1.24.2
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/openai/openai-go v0.1.0-beta.10
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/bytedance/sonic v1.13.2 // indirect
 	github.com/bytedance/sonic/loader v0.2.4 // indirect
 	github.com/cloudwego/base64x v0.1.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -26,6 +28,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tidwall/gjson v1.14.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -15,11 +15,11 @@ func ConnectDb() *DatabaseService {
 	db, err := sql.Open("postgres", connStr)
 
 	if err != nil {
-		fmt.Println("Failed to connect to database instance %v", err)
+		fmt.Printf("Failed to connect to database instance %v\n", err)
 	}
 
 	if err := db.Ping(); err != nil {
-		fmt.Println("Failed to connect to database instance %v", err)
+		fmt.Printf("Failed to connect to database instance %v\n", err)
 	}
 
 	return &DatabaseService{db: db}

--- a/internal/handlers/message_handler/message.go
+++ b/internal/handlers/message_handler/message.go
@@ -95,9 +95,12 @@ func validateMessage(message groupme.Message) error {
 // }
 
 func cleanMessage(message string) string {
-	cleanedMessage := strings.TrimPrefix(message, "hey crowfather")
-	cleanedMessage = strings.TrimPrefix(cleanedMessage, ",")
-	cleanedMessage = strings.TrimSpace(cleanedMessage)
-
-	return cleanedMessage
+	const prefix = "hey crowfather"
+	if strings.HasPrefix(strings.ToLower(message), prefix) {
+		message = message[len(prefix):]
+	}
+	message = strings.TrimSpace(message)
+	message = strings.TrimPrefix(message, ",")
+	message = strings.TrimSpace(message)
+	return message
 }

--- a/internal/handlers/message_handler/message_test.go
+++ b/internal/handlers/message_handler/message_test.go
@@ -1,0 +1,21 @@
+package message_handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Bug 3: cleanMessage must strip the prefix case-insensitively and handle a
+// space before the trailing comma.
+
+func TestCleanMessageCaseInsensitivePrefix(t *testing.T) {
+	// Original: strings.TrimPrefix(message, "hey crowfather") is case-sensitive,
+	// so a capitalised trigger is not stripped before being sent to OpenAI.
+	assert.Equal(t, "what time is it?", cleanMessage("Hey Crowfather, what time is it?"))
+}
+
+func TestCleanMessageSpaceBeforeComma(t *testing.T) {
+	// Original: TrimPrefix(",") silently skips the comma when whitespace precedes it.
+	assert.Equal(t, "what time is it?", cleanMessage("hey crowfather , what time is it?"))
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -14,7 +14,7 @@ func main() {
 	config, err := config.LoadConfig()
 
 	if err != nil {
-		fmt.Println("Failed to load config %v", err)
+		fmt.Printf("Failed to load config %v\n", err)
 		return
 	}
 

--- a/internal/open_ai/open_ai.go
+++ b/internal/open_ai/open_ai.go
@@ -65,6 +65,8 @@ func (oai *OpenAIService) GetOrCreateThread(contextID string) (string, error) {
 }
 
 func (oai *OpenAIService) GetThreadId(contextID string) string {
+	oai.mu.RLock()
+	defer oai.mu.RUnlock()
 	return oai.ThreadIds[contextID]
 }
 
@@ -131,7 +133,9 @@ func (oai *OpenAIService) GetResponse(run openai.Run, messageId string) (string,
 			case openai.RunStatusFailed:
 				return "", fmt.Errorf("Run failed")
 			case openai.RunStatusCancelled:
+				return "", fmt.Errorf("run was cancelled")
 			case openai.RunStatusRequiresAction:
+				return "", fmt.Errorf("run requires action (tool calls not implemented)")
 			default:
 				return "", fmt.Errorf("failed to get run status with status %s", resp.Status)
 			}

--- a/internal/open_ai/open_ai_test.go
+++ b/internal/open_ai/open_ai_test.go
@@ -1,0 +1,91 @@
+package open_ai
+
+import (
+	"crowfather/internal/config"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bug 1: GetThreadId must hold RLock when reading ThreadIds.
+// Run with: go test -race ./internal/open_ai
+func TestGetThreadIdRace(t *testing.T) {
+	svc := &OpenAIService{
+		ThreadIds: map[string]string{"group1": "thread_abc"},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			svc.mu.Lock()
+			svc.ThreadIds["group2"] = "thread_xyz"
+			svc.mu.Unlock()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = svc.GetThreadId("group1")
+		}()
+	}
+	wg.Wait()
+}
+
+// Bug 2 helpers.
+
+func runStatusServer(t *testing.T, status string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"run_1","object":"thread.run","created_at":0,"thread_id":"thread_1","assistant_id":"asst_1","status":%q,"model":"gpt-4o","tools":[],"metadata":{},"parallel_tool_calls":true,"response_format":"auto","tool_choice":"auto"}`, status)
+	}))
+}
+
+func newTestService(t *testing.T, baseURL string) *OpenAIService {
+	t.Helper()
+	opts := []option.RequestOption{
+		option.WithAPIKey("test"),
+		option.WithBaseURL(baseURL),
+	}
+	threadC := openai.NewBetaThreadService(opts[0])
+	return &OpenAIService{
+		ThreadClient: &threadC,
+		Config:       &config.OpenAIConfig{Timeout: 500 * time.Millisecond},
+		Options:      opts,
+		ThreadIds:    make(map[string]string),
+	}
+}
+
+// Bug 2a: cancelled run must return an error immediately, not loop until timeout.
+func TestGetResponseCancelledReturnsError(t *testing.T) {
+	server := runStatusServer(t, "cancelled")
+	defer server.Close()
+
+	svc := newTestService(t, server.URL)
+	run := openai.Run{ID: "run_1", ThreadID: "thread_1"}
+
+	_, err := svc.GetResponse(run, "msg_1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cancelled")
+}
+
+// Bug 2b: requires_action run must return an error immediately, not loop until timeout.
+func TestGetResponseRequiresActionReturnsError(t *testing.T) {
+	server := runStatusServer(t, "requires_action")
+	defer server.Close()
+
+	svc := newTestService(t, server.URL)
+	run := openai.Run{ID: "run_1", ThreadID: "thread_1"}
+
+	_, err := svc.GetResponse(run, "msg_1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires action")
+}


### PR DESCRIPTION
Bug fixes:
- open_ai: hold RLock in GetThreadId to prevent data race with concurrent writes from GetOrCreateThread
- open_ai: return errors immediately for RunStatusCancelled and RunStatusRequiresAction in GetResponse; previously both fell through the switch with empty bodies, causing a tight polling loop until the context timeout fired
- message_handler: make cleanMessage case-insensitive when stripping the "hey crowfather" trigger prefix, and trim whitespace before stripping the trailing comma so inputs like "Hey Crowfather , ..." are handled correctly

Tests:
- Add open_ai_test.go covering the race condition (run with -race) and both terminal run statuses
- Add message_test.go covering the capitalised prefix and space-before-comma cases; each test would have failed on the original code

Vet fixes:
- Replace fmt.Println with fmt.Printf in database.go (x2) and main.go where %v format verbs were passed to a non-formatting function