### PR TITLE
Add PostgreSQL persistence for OpenAI thread IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0
+	github.com/lib/pq v1.11.2
 	github.com/openai/openai-go v0.1.0-beta.10
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQe
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
+github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,23 +4,30 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+
+	_ "github.com/lib/pq"
 )
 
 type DatabaseService struct {
 	db *sql.DB
 }
 
-func ConnectDb() *DatabaseService {
-	connStr := fmt.Sprintf("user=%s password=%s host=%s dbname=%s", os.Getenv("DB_USER"), os.Getenv("DB_PASS"), os.Getenv("HOST"), os.Getenv("DB_NAME"))
+func (s *DatabaseService) DB() *sql.DB {
+	return s.db
+}
+
+func ConnectDb() (*DatabaseService, error) {
+	connStr := fmt.Sprintf("user=%s password=%s host=%s dbname=%s sslmode=disable",
+		os.Getenv("DB_USER"), os.Getenv("DB_PASS"), os.Getenv("HOST"), os.Getenv("DB_NAME"))
 	db, err := sql.Open("postgres", connStr)
 
 	if err != nil {
-		fmt.Printf("Failed to connect to database instance %v\n", err)
+		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
 
 	if err := db.Ping(); err != nil {
-		fmt.Printf("Failed to connect to database instance %v\n", err)
+		return nil, fmt.Errorf("failed to reach database: %w", err)
 	}
 
-	return &DatabaseService{db: db}
+	return &DatabaseService{db: db}, nil
 }

--- a/internal/database/thread_repository.go
+++ b/internal/database/thread_repository.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type PgThreadRepository struct {
+	db *sql.DB
+}
+
+func NewPgThreadRepository(db *sql.DB) *PgThreadRepository {
+	return &PgThreadRepository{db: db}
+}
+
+func (r *PgThreadRepository) Migrate(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS thread_ids (
+			context_id  TEXT PRIMARY KEY,
+			thread_id   TEXT NOT NULL,
+			created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to run thread_ids migration: %w", err)
+	}
+	return nil
+}
+
+func (r *PgThreadRepository) GetThreadID(ctx context.Context, contextID string) (string, error) {
+	var threadID string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT thread_id FROM thread_ids WHERE context_id = $1`,
+		contextID,
+	).Scan(&threadID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get thread id for context %s: %w", contextID, err)
+	}
+	return threadID, nil
+}
+
+func (r *PgThreadRepository) SaveThreadID(ctx context.Context, contextID, threadID string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO thread_ids (context_id, thread_id)
+		VALUES ($1, $2)
+		ON CONFLICT (context_id) DO UPDATE
+			SET thread_id  = EXCLUDED.thread_id,
+			    updated_at = NOW()
+	`, contextID, threadID)
+	if err != nil {
+		return fmt.Errorf("failed to save thread id for context %s: %w", contextID, err)
+	}
+	return nil
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"crowfather/internal/config"
+	"crowfather/internal/database"
 	"crowfather/internal/groupme"
 	"crowfather/internal/open_ai"
 	"crowfather/internal/router"
@@ -10,25 +12,35 @@ import (
 )
 
 func main() {
-	//db := database.ConnectDb();
-	config, err := config.LoadConfig()
+	cfg, err := config.LoadConfig()
 
 	if err != nil {
-		fmt.Printf("Failed to load config %v\n", err)
+		fmt.Printf("Failed to load config: %v\n", err)
 		return
 	}
 
-	oai := open_ai.NewOpenAIService(config.OpenAI)
-	gms := groupme.NewGroupMeService(config.GroupMe)
-	router, err := router.NewRouter(oai, gms, config)
+	var repo open_ai.ThreadRepository
+	dbSvc, err := database.ConnectDb()
+	if err != nil {
+		fmt.Printf("Database unavailable, running in memory-only mode: %v\n", err)
+	} else {
+		pgRepo := database.NewPgThreadRepository(dbSvc.DB())
+		if err := pgRepo.Migrate(context.Background()); err != nil {
+			fmt.Printf("Schema migration failed, running in memory-only mode: %v\n", err)
+		} else {
+			repo = pgRepo
+		}
+	}
+
+	oai := open_ai.NewOpenAIService(cfg.OpenAI, repo)
+	gms := groupme.NewGroupMeService(cfg.GroupMe)
+	r, err := router.NewRouter(oai, gms, cfg)
 
 	if err != nil {
 		return
 	}
 
-	r := gin.Default()
-
-	router.RegisterRoutes(r)
-
-	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
+	engine := gin.Default()
+	r.RegisterRoutes(engine)
+	engine.Run()
 }

--- a/internal/open_ai/open_ai.go
+++ b/internal/open_ai/open_ai.go
@@ -19,15 +19,24 @@ type Config struct {
 	Uri          string
 }
 
+// ThreadRepository is the persistence contract for OpenAI thread IDs.
+// The concrete implementation lives in the database package.
+// A nil value is valid; OpenAIService falls back to in-memory only.
+type ThreadRepository interface {
+	GetThreadID(ctx context.Context, contextID string) (string, error)
+	SaveThreadID(ctx context.Context, contextID, threadID string) error
+}
+
 type OpenAIService struct {
 	ThreadClient *openai.BetaThreadService
 	ThreadIds    map[string]string
 	Config       *config.OpenAIConfig
 	Options      []option.RequestOption
+	Repo         ThreadRepository
 	mu           sync.RWMutex
 }
 
-func NewOpenAIService(config *config.OpenAIConfig) *OpenAIService {
+func NewOpenAIService(config *config.OpenAIConfig, repo ThreadRepository) *OpenAIService {
 	var opts = []option.RequestOption{
 		option.WithAPIKey(config.APIKey),
 		option.WithBaseURL(config.BaseURL),
@@ -42,6 +51,7 @@ func NewOpenAIService(config *config.OpenAIConfig) *OpenAIService {
 		Config:       config,
 		Options:      opts,
 		ThreadIds:    make(map[string]string),
+		Repo:         repo,
 	}
 }
 
@@ -53,10 +63,26 @@ func (oai *OpenAIService) GetOrCreateThread(contextID string) (string, error) {
 		return threadId, nil
 	}
 
+	if oai.Repo != nil {
+		threadId, err := oai.Repo.GetThreadID(context.Background(), contextID)
+		if err != nil {
+			fmt.Printf("GetOrCreateThread: db lookup failed for %s: %v\n", contextID, err)
+		} else if threadId != "" {
+			oai.ThreadIds[contextID] = threadId
+			return threadId, nil
+		}
+	}
+
 	threadId, err := oai.CreateThread()
 
 	if err != nil {
 		return "", err
+	}
+
+	if oai.Repo != nil {
+		if err := oai.Repo.SaveThreadID(context.Background(), contextID, threadId); err != nil {
+			fmt.Printf("GetOrCreateThread: db save failed for %s: %v\n", contextID, err)
+		}
 	}
 
 	oai.ThreadIds[contextID] = threadId

--- a/internal/open_ai/open_ai_test.go
+++ b/internal/open_ai/open_ai_test.go
@@ -61,6 +61,7 @@ func newTestService(t *testing.T, baseURL string) *OpenAIService {
 		Config:       &config.OpenAIConfig{Timeout: 500 * time.Millisecond},
 		Options:      opts,
 		ThreadIds:    make(map[string]string),
+		Repo:         nil,
 	}
 }
 

--- a/internal/open_ai/thread_repository_test.go
+++ b/internal/open_ai/thread_repository_test.go
@@ -1,0 +1,145 @@
+package open_ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockThreadRepo struct {
+	mu        sync.Mutex
+	data      map[string]string
+	getErr    error
+	saveErr   error
+	getCalls  int
+	saveCalls int
+}
+
+func (m *mockThreadRepo) GetThreadID(_ context.Context, contextID string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.getCalls++
+	if m.getErr != nil {
+		return "", m.getErr
+	}
+	return m.data[contextID], nil
+}
+
+func (m *mockThreadRepo) SaveThreadID(_ context.Context, contextID, threadID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.saveCalls++
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.data[contextID] = threadID
+	return nil
+}
+
+func newThreadServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"thread_new","object":"thread","created_at":0,"metadata":{},"tool_resources":{}}`)
+	}))
+}
+
+// Cache hit: repo is never called when the thread is already in the in-memory map.
+func TestGetOrCreateThread_CacheHit(t *testing.T) {
+	repo := &mockThreadRepo{data: make(map[string]string)}
+	svc := &OpenAIService{
+		ThreadIds: map[string]string{"group1": "thread_cached"},
+		Repo:      repo,
+	}
+
+	id, err := svc.GetOrCreateThread("group1")
+	require.NoError(t, err)
+	assert.Equal(t, "thread_cached", id)
+	assert.Equal(t, 0, repo.getCalls)
+	assert.Equal(t, 0, repo.saveCalls)
+}
+
+// DB hit: thread absent from cache but found in DB; cache is warmed.
+func TestGetOrCreateThread_DBHit(t *testing.T) {
+	repo := &mockThreadRepo{data: map[string]string{"group1": "thread_from_db"}}
+	svc := &OpenAIService{
+		ThreadIds: make(map[string]string),
+		Repo:      repo,
+	}
+
+	id, err := svc.GetOrCreateThread("group1")
+	require.NoError(t, err)
+	assert.Equal(t, "thread_from_db", id)
+	assert.Equal(t, 1, repo.getCalls)
+	assert.Equal(t, 0, repo.saveCalls)
+	assert.Equal(t, "thread_from_db", svc.ThreadIds["group1"])
+}
+
+// Nil repo: no panic when DB is not configured.
+func TestGetOrCreateThread_NilRepo(t *testing.T) {
+	server := newThreadServer(t)
+	defer server.Close()
+
+	svc := newTestService(t, server.URL)
+	svc.Repo = nil
+
+	id, err := svc.GetOrCreateThread("group_no_db")
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+}
+
+// DB GetThreadID error: service falls back to creating a new thread rather than returning an error.
+func TestGetOrCreateThread_DBGetError_FallsBack(t *testing.T) {
+	server := newThreadServer(t)
+	defer server.Close()
+
+	repo := &mockThreadRepo{data: make(map[string]string), getErr: errors.New("db down")}
+	svc := newTestService(t, server.URL)
+	svc.Repo = repo
+
+	id, err := svc.GetOrCreateThread("group1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+}
+
+// DB SaveThreadID error: thread is still returned and cached in-memory.
+func TestGetOrCreateThread_DBSaveError_StillReturns(t *testing.T) {
+	server := newThreadServer(t)
+	defer server.Close()
+
+	repo := &mockThreadRepo{data: make(map[string]string), saveErr: errors.New("db write failed")}
+	svc := newTestService(t, server.URL)
+	svc.Repo = repo
+
+	id, err := svc.GetOrCreateThread("group1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, id)
+	assert.Equal(t, id, svc.ThreadIds["group1"])
+}
+
+// Concurrent calls: no data races (run with go test -race ./internal/open_ai).
+func TestGetOrCreateThread_Race(t *testing.T) {
+	server := newThreadServer(t)
+	defer server.Close()
+
+	repo := &mockThreadRepo{data: make(map[string]string)}
+	svc := newTestService(t, server.URL)
+	svc.Repo = repo
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = svc.GetOrCreateThread("shared_group")
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Previously, OpenAI thread IDs were stored only in an in-memory map inside OpenAIService, meaning every restart caused the bot to lose all conversation context and create fresh threads for every group.

This commit wires up the existing (stub) database package to PostgreSQL so thread IDs survive restarts. The database is fully optional — if the DB env vars are absent or Postgres is unreachable, the service logs a warning and continues in memory-only mode without crashing.

Changes:

internal/database/database.go
- Add github.com/lib/pq blank import to register the postgres driver
- Change ConnectDb() return type from *DatabaseService to (*DatabaseService, error) so callers can handle connection failures instead of silently receiving a broken service
- Add sslmode=disable to the connection string (lib/pq requires an explicit sslmode)
- Add DB() *sql.DB accessor so callers can pass the underlying *sql.DB to the repository without exposing the struct field directly

internal/database/thread_repository.go (new)
- PgThreadRepository implements the ThreadRepository interface defined in open_ai
- Migrate(ctx): idempotent CREATE TABLE IF NOT EXISTS for the thread_ids table (context_id TEXT PRIMARY KEY, thread_id TEXT NOT NULL, created_at/updated_at TIMESTAMPTZ)
- GetThreadID(ctx, contextID): SELECT by context_id; returns "", nil on not-found
- SaveThreadID(ctx, contextID, threadID): INSERT ... ON CONFLICT DO UPDATE (upsert) so a second instance or retry path never causes a unique-constraint error

internal/open_ai/open_ai.go
- Define ThreadRepository interface in the consumer package (Go convention)
- Add Repo ThreadRepository field to OpenAIService (nil == memory-only)
- Update NewOpenAIService signature to accept a ThreadRepository parameter
- Rewrite GetOrCreateThread with a cache → DB → create → persist flow:
    1. Return from in-memory cache if present (fast path, no DB round-trip)
    2. If Repo != nil, look up in DB; warm cache and return on hit
    3. Create a new thread via the OpenAI API
    4. If Repo != nil, persist the new thread ID (DB errors are logged, not fatal)
    5. Update the in-memory cache and return DB errors at any step are non-fatal so a DB outage does not break message handling

internal/open_ai/open_ai_test.go
- Add explicit Repo: nil to newTestService so it compiles against the updated constructor

internal/open_ai/thread_repository_test.go (new)
- mockThreadRepo implements ThreadRepository for use in unit tests
- TestGetOrCreateThread_CacheHit: repo is never called when thread is in cache
- TestGetOrCreateThread_DBHit: cache is warmed from DB on miss
- TestGetOrCreateThread_NilRepo: no panic when Repo is nil
- TestGetOrCreateThread_DBGetError_FallsBack: DB read error causes graceful fallback to creating a new thread
- TestGetOrCreateThread_DBSaveError_StillReturns: DB write error does not prevent the thread from being returned and cached
- TestGetOrCreateThread_Race: concurrent calls exercise the mutex (run with -race)

internal/main.go
- Uncomment and rewrite the database initialization block
- ConnectDb failure → log warning, repo stays nil (memory-only)
- Migrate failure → log warning, repo stays nil (memory-only)
- Pass repo to NewOpenAIService (nil is valid)
- Rename local variable config → cfg to avoid shadowing the config package import

go.mod / go.sum
- Add github.com/lib/pq v1.11.2

.gitignore (new)
- Ignore CLAUDE.md (working file, not for version control yet)