### PR TITLE
Add sports data reconciliation with ESPN + Sleeper APIs and OpenAI ve…

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -27,14 +29,24 @@ type OpenAIConfig struct {
 }
 
 type Config struct {
-	OpenAI     *OpenAIConfig  `json:"openai"`
-	GroupMe    *GroupMeConfig `json:"groupme"`
-	Auth       *AuthConfig    `json:"auth"`
-	Assistants *Assistants    `json:"assistants"`
+	OpenAI     *OpenAIConfig     `json:"openai"`
+	GroupMe    *GroupMeConfig    `json:"groupme"`
+	Auth       *AuthConfig       `json:"auth"`
+	Assistants *Assistants       `json:"assistants"`
+	Reconciler *ReconcilerConfig `json:"reconciler"` // nil if not configured
 }
 
 type AuthConfig struct {
 	APIKey string `json:"api_key"`
+}
+
+type ReconcilerConfig struct {
+	LeagueIDs         []string      // SLEEPER_LEAGUE_IDS (comma-separated)
+	OnStartup         bool          // RECONCILE_ON_STARTUP (default true)
+	Interval          time.Duration // RECONCILE_INTERVAL_HOURS (default 168h)
+	CooldownMinutes   time.Duration // RECONCILE_COOLDOWN_MINUTES (default 30m)
+	ApprovedUsers     []string      // RECONCILE_APPROVED_USERS (comma-separated GroupMe user_ids)
+	TransactionRounds int           // RECONCILE_TRANSACTION_ROUNDS (default 2)
 }
 
 func LoadConfig() (*Config, error) {
@@ -61,11 +73,14 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
+	reconcilerConfig := loadReconcilerConfig()
+
 	return &Config{
 		OpenAI:     openAIConfig,
 		GroupMe:    groupMeConfig,
 		Auth:       authConfig,
 		Assistants: assistants,
+		Reconciler: reconcilerConfig,
 	}, nil
 }
 
@@ -141,4 +156,69 @@ func loadAssistants() (*Assistants, error) {
 		MeltdownAssistantID: MeltdownAssistantID,
 		TestAssistantID:     TestAssistantID,
 	}, nil
+}
+
+// loadReconcilerConfig loads optional reconciler settings. Returns nil if no
+// league IDs are configured, which disables the reconciler entirely.
+func loadReconcilerConfig() *ReconcilerConfig {
+	leagueIDsRaw := os.Getenv("SLEEPER_LEAGUE_IDS")
+	if leagueIDsRaw == "" {
+		return nil
+	}
+
+	leagueIDs := splitTrimmed(leagueIDsRaw)
+	if len(leagueIDs) == 0 {
+		return nil
+	}
+
+	onStartup := true
+	if v := os.Getenv("RECONCILE_ON_STARTUP"); v == "false" {
+		onStartup = false
+	}
+
+	intervalHours := 168
+	if v := os.Getenv("RECONCILE_INTERVAL_HOURS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			intervalHours = n
+		}
+	}
+
+	cooldownMinutes := 30
+	if v := os.Getenv("RECONCILE_COOLDOWN_MINUTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cooldownMinutes = n
+		}
+	}
+
+	transactionRounds := 2
+	if v := os.Getenv("RECONCILE_TRANSACTION_ROUNDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			transactionRounds = n
+		}
+	}
+
+	var approvedUsers []string
+	if v := os.Getenv("RECONCILE_APPROVED_USERS"); v != "" {
+		approvedUsers = splitTrimmed(v)
+	}
+
+	return &ReconcilerConfig{
+		LeagueIDs:         leagueIDs,
+		OnStartup:         onStartup,
+		Interval:          time.Duration(intervalHours) * time.Hour,
+		CooldownMinutes:   time.Duration(cooldownMinutes) * time.Minute,
+		ApprovedUsers:     approvedUsers,
+		TransactionRounds: transactionRounds,
+	}
+}
+
+func splitTrimmed(s string) []string {
+	parts := strings.Split(s, ",")
+	var out []string
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,3 +33,95 @@ func TestLoadOpenAIConfigMissing(t *testing.T) {
 		t.Fatalf("expected error when OPENAI_API_KEY missing")
 	}
 }
+
+func TestLoadReconcilerConfig_NoLeagueIDs(t *testing.T) {
+	t.Setenv("SLEEPER_LEAGUE_IDS", "")
+	if cfg := loadReconcilerConfig(); cfg != nil {
+		t.Fatalf("expected nil config when SLEEPER_LEAGUE_IDS is empty, got %+v", cfg)
+	}
+}
+
+func TestLoadReconcilerConfig_WithLeagueIDs(t *testing.T) {
+	t.Setenv("SLEEPER_LEAGUE_IDS", "league1,league2")
+	t.Setenv("RECONCILE_ON_STARTUP", "false")
+	t.Setenv("RECONCILE_INTERVAL_HOURS", "24")
+	t.Setenv("RECONCILE_COOLDOWN_MINUTES", "15")
+	t.Setenv("RECONCILE_TRANSACTION_ROUNDS", "3")
+	t.Setenv("RECONCILE_APPROVED_USERS", "user1,user2")
+
+	cfg := loadReconcilerConfig()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if len(cfg.LeagueIDs) != 2 || cfg.LeagueIDs[0] != "league1" || cfg.LeagueIDs[1] != "league2" {
+		t.Errorf("unexpected league IDs: %v", cfg.LeagueIDs)
+	}
+	if cfg.OnStartup != false {
+		t.Error("expected OnStartup=false")
+	}
+	if cfg.Interval.Hours() != 24 {
+		t.Errorf("unexpected interval: %v", cfg.Interval)
+	}
+	if cfg.CooldownMinutes.Minutes() != 15 {
+		t.Errorf("unexpected cooldown: %v", cfg.CooldownMinutes)
+	}
+	if cfg.TransactionRounds != 3 {
+		t.Errorf("unexpected transaction rounds: %d", cfg.TransactionRounds)
+	}
+	if len(cfg.ApprovedUsers) != 2 || cfg.ApprovedUsers[0] != "user1" {
+		t.Errorf("unexpected approved users: %v", cfg.ApprovedUsers)
+	}
+}
+
+func TestLoadReconcilerConfig_Defaults(t *testing.T) {
+	t.Setenv("SLEEPER_LEAGUE_IDS", "league1")
+	t.Setenv("RECONCILE_ON_STARTUP", "")
+	t.Setenv("RECONCILE_INTERVAL_HOURS", "")
+	t.Setenv("RECONCILE_COOLDOWN_MINUTES", "")
+	t.Setenv("RECONCILE_TRANSACTION_ROUNDS", "")
+	t.Setenv("RECONCILE_APPROVED_USERS", "")
+
+	cfg := loadReconcilerConfig()
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+	if !cfg.OnStartup {
+		t.Error("expected OnStartup=true by default")
+	}
+	if cfg.Interval.Hours() != 168 {
+		t.Errorf("expected 168h default interval, got %v", cfg.Interval)
+	}
+	if cfg.CooldownMinutes.Minutes() != 30 {
+		t.Errorf("expected 30m default cooldown, got %v", cfg.CooldownMinutes)
+	}
+	if cfg.TransactionRounds != 2 {
+		t.Errorf("expected 2 default transaction rounds, got %d", cfg.TransactionRounds)
+	}
+	if len(cfg.ApprovedUsers) != 0 {
+		t.Errorf("expected empty approved users by default, got %v", cfg.ApprovedUsers)
+	}
+}
+
+func TestSplitTrimmed(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected []string
+	}{
+		{"a,b,c", []string{"a", "b", "c"}},
+		{" a , b ", []string{"a", "b"}},
+		{"", nil},
+		{",,,", nil},
+	}
+	for _, tc := range cases {
+		got := splitTrimmed(tc.input)
+		if len(got) != len(tc.expected) {
+			t.Errorf("splitTrimmed(%q) = %v, want %v", tc.input, got, tc.expected)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.expected[i] {
+				t.Errorf("splitTrimmed(%q)[%d] = %q, want %q", tc.input, i, got[i], tc.expected[i])
+			}
+		}
+	}
+}

--- a/internal/database/metadata_repository.go
+++ b/internal/database/metadata_repository.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type PgMetadataRepository struct {
+	db *sql.DB
+}
+
+func NewPgMetadataRepository(db *sql.DB) *PgMetadataRepository {
+	return &PgMetadataRepository{db: db}
+}
+
+func (r *PgMetadataRepository) Migrate(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS metadata (
+			key        TEXT PRIMARY KEY,
+			value      TEXT NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to run metadata migration: %w", err)
+	}
+	return nil
+}
+
+func (r *PgMetadataRepository) GetMetadata(ctx context.Context, key string) (string, error) {
+	var value string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT value FROM metadata WHERE key = $1`, key,
+	).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get metadata key %s: %w", key, err)
+	}
+	return value, nil
+}
+
+func (r *PgMetadataRepository) SetMetadata(ctx context.Context, key, value string) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO metadata (key, value)
+		VALUES ($1, $2)
+		ON CONFLICT (key) DO UPDATE
+			SET value      = EXCLUDED.value,
+			    updated_at = NOW()
+	`, key, value)
+	if err != nil {
+		return fmt.Errorf("failed to set metadata key %s: %w", key, err)
+	}
+	return nil
+}

--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -1,0 +1,108 @@
+package espn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const defaultRosterURLFmt = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/teams/%d/roster"
+
+// maxTeamID: ESPN team IDs run 1–34 (some may be unused); we skip empty responses.
+const maxTeamID = 34
+
+type ESPNService struct {
+	client       *http.Client
+	rosterURLFmt string // format string with one %d for team ID
+}
+
+func NewESPNService() *ESPNService {
+	return &ESPNService{
+		client:       &http.Client{Timeout: 15 * time.Second},
+		rosterURLFmt: defaultRosterURLFmt,
+	}
+}
+
+func (s *ESPNService) FetchAllTeamRosters(ctx context.Context) ([]TeamWithRoster, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	type result struct {
+		roster *TeamWithRoster
+		err    error
+	}
+
+	results := make(chan result, maxTeamID)
+	var wg sync.WaitGroup
+
+	for i := 1; i <= maxTeamID; i++ {
+		wg.Add(1)
+		go func(teamID int) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					results <- result{err: fmt.Errorf("panic fetching team %d: %v", teamID, rec)}
+				}
+				wg.Done()
+			}()
+			twr, err := s.fetchTeamRoster(ctx, teamID)
+			results <- result{roster: twr, err: err}
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	var teams []TeamWithRoster
+	for r := range results {
+		if r.err != nil || r.roster == nil {
+			continue
+		}
+		teams = append(teams, *r.roster)
+	}
+
+	if len(teams) == 0 {
+		return nil, fmt.Errorf("failed to fetch any ESPN team rosters")
+	}
+
+	return teams, nil
+}
+
+func (s *ESPNService) fetchTeamRoster(ctx context.Context, teamID int) (*TeamWithRoster, error) {
+	url := fmt.Sprintf(s.rosterURLFmt, teamID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil // skip invalid/non-existent team IDs silently
+	}
+
+	var rr RosterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rr); err != nil {
+		return nil, err
+	}
+
+	if rr.Team.TeamID == "" {
+		return nil, nil
+	}
+
+	twr := &TeamWithRoster{Team: rr.Team}
+	for _, pos := range rr.Athletes {
+		for _, athlete := range pos.Items {
+			athlete.Position = pos.Position
+			twr.Roster = append(twr.Roster, athlete)
+		}
+	}
+
+	return twr, nil
+}

--- a/internal/espn/espn_struct.go
+++ b/internal/espn/espn_struct.go
@@ -1,0 +1,34 @@
+package espn
+
+type RosterResponse struct {
+	Timestamp string     `json:"timestamp"`
+	Status    string     `json:"status"`
+	Athletes  []Position `json:"athletes"`
+	Team      Team       `json:"team"`
+}
+
+type Position struct {
+	Position string    `json:"position"`
+	Items    []Athlete `json:"items"`
+}
+
+type Athlete struct {
+	AthleteID   string `json:"id"`
+	FirstName   string `json:"firstName"`
+	LastName    string `json:"lastName"`
+	DisplayName string `json:"displayName"`
+	Position    string `json:"position"`
+}
+
+type Team struct {
+	TeamID          string `json:"id"`
+	Name            string `json:"name"`
+	RecordSummary   string `json:"recordSummary"`
+	SeasonSummary   string `json:"seasonSummary"`
+	StandingSummary string `json:"standingSummary"`
+}
+
+type TeamWithRoster struct {
+	Team   Team      `json:"team"`
+	Roster []Athlete `json:"roster"`
+}

--- a/internal/espn/espn_test.go
+++ b/internal/espn/espn_test.go
@@ -1,0 +1,126 @@
+package espn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rosterJSON(teamID, teamName string, athletes []Athlete) string {
+	positions := []Position{{Position: "QB", Items: athletes}}
+	resp := RosterResponse{
+		Team: Team{
+			TeamID:          teamID,
+			Name:            teamName,
+			RecordSummary:   "10-7",
+			SeasonSummary:   "2024",
+			StandingSummary: "1st AFC West",
+		},
+		Athletes: positions,
+	}
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func TestFetchAllTeamRosters_ReturnsValidTeams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var teamID int
+		fmt.Sscanf(r.URL.Path, "/%d", &teamID)
+		if teamID == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, rosterJSON("1", "Kansas City Chiefs", []Athlete{
+				{AthleteID: "1", DisplayName: "Patrick Mahomes", Position: "QB"},
+			}))
+			return
+		}
+		// All other team IDs return 404 (simulates non-existent teams).
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc := &ESPNService{
+		client:       server.Client(),
+		rosterURLFmt: server.URL + "/%d",
+	}
+
+	teams, err := svc.FetchAllTeamRosters(context.Background())
+	require.NoError(t, err)
+	require.Len(t, teams, 1)
+	assert.Equal(t, "Kansas City Chiefs", teams[0].Team.Name)
+	assert.Equal(t, "10-7", teams[0].Team.RecordSummary)
+	require.Len(t, teams[0].Roster, 1)
+	assert.Equal(t, "Patrick Mahomes", teams[0].Roster[0].DisplayName)
+	assert.Equal(t, "QB", teams[0].Roster[0].Position)
+}
+
+func TestFetchAllTeamRosters_AggregatesMultipleTeams(t *testing.T) {
+	teams := map[int]string{1: "Chiefs", 2: "Eagles"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var id int
+		fmt.Sscanf(r.URL.Path, "/%d", &id)
+		if name, ok := teams[id]; ok {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, rosterJSON(fmt.Sprint(id), name, nil))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc := &ESPNService{client: server.Client(), rosterURLFmt: server.URL + "/%d"}
+	got, err := svc.FetchAllTeamRosters(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+}
+
+func TestFetchAllTeamRosters_AllFailReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc := &ESPNService{client: server.Client(), rosterURLFmt: server.URL + "/%d"}
+	_, err := svc.FetchAllTeamRosters(context.Background())
+	assert.Error(t, err)
+}
+
+func TestFetchAllTeamRosters_PositionTaggedOnAthletes(t *testing.T) {
+	// Verifies that the position from the Position group is set on each Athlete.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var id int
+		fmt.Sscanf(r.URL.Path, "/%d", &id)
+		if id != 1 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp := RosterResponse{
+			Team: Team{TeamID: "1", Name: "Chiefs"},
+			Athletes: []Position{
+				{Position: "QB", Items: []Athlete{{AthleteID: "10", DisplayName: "Mahomes"}}},
+				{Position: "WR", Items: []Athlete{{AthleteID: "11", DisplayName: "Rice"}}},
+			},
+		}
+		b, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	}))
+	defer server.Close()
+
+	svc := &ESPNService{client: server.Client(), rosterURLFmt: server.URL + "/%d"}
+	teams, err := svc.FetchAllTeamRosters(context.Background())
+	require.NoError(t, err)
+	require.Len(t, teams[0].Roster, 2)
+
+	byName := make(map[string]Athlete)
+	for _, a := range teams[0].Roster {
+		byName[a.DisplayName] = a
+	}
+	assert.Equal(t, "QB", byName["Mahomes"].Position)
+	assert.Equal(t, "WR", byName["Rice"].Position)
+}

--- a/internal/groupme/groupme.go
+++ b/internal/groupme/groupme.go
@@ -59,6 +59,28 @@ func (g *GroupMeService) buildUrl() *url.URL {
 	}
 }
 
+// SendRawMessage sends text to the GroupMe group without an @mention prefix.
+// Used for bot-initiated messages such as reconciliation completion summaries.
+func (g *GroupMeService) SendRawMessage(text string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), g.Config.Timeout)
+	defer cancel()
+
+	payload, err := json.Marshal(MessageSendRequest{
+		BotId: g.Config.BotID,
+		Text:  text,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build raw message payload: %w", err)
+	}
+
+	request := g.buildRequest(ctx, payload)
+	ok, err := g.sendRequest(request)
+	if err != nil || !ok {
+		return fmt.Errorf("failed to send raw message: %w", err)
+	}
+	return nil
+}
+
 func (g *GroupMeService) buildPayload(message Message, response string) ([]byte, error) {
 	return json.Marshal(MessageSendRequest{
 		BotId: g.Config.BotID,

--- a/internal/groupme/groupme_test.go
+++ b/internal/groupme/groupme_test.go
@@ -79,3 +79,45 @@ func TestSendRequestFailure(t *testing.T) {
 		t.Fatalf("expected failure")
 	}
 }
+
+func TestSendRawMessage_Success(t *testing.T) {
+	var gotBody MessageSendRequest
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	svc := &GroupMeService{
+		Client: server.Client(),
+		Config: &config.GroupMeConfig{BotID: "bot123", Host: u.Host, Path: u.Path, Timeout: 5 * 1000000000},
+	}
+
+	if err := svc.SendRawMessage("Hello, league!"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody.BotId != "bot123" {
+		t.Errorf("expected bot_id=bot123, got %q", gotBody.BotId)
+	}
+	if gotBody.Text != "Hello, league!" {
+		t.Errorf("expected text without @mention, got %q", gotBody.Text)
+	}
+}
+
+func TestSendRawMessage_Failure(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	svc := &GroupMeService{
+		Client: server.Client(),
+		Config: &config.GroupMeConfig{Host: u.Host, Path: u.Path, Timeout: 5 * 1000000000},
+	}
+
+	if err := svc.SendRawMessage("test"); err == nil {
+		t.Fatal("expected error on non-202 response")
+	}
+}

--- a/internal/main.go
+++ b/internal/main.go
@@ -4,38 +4,83 @@ import (
 	"context"
 	"crowfather/internal/config"
 	"crowfather/internal/database"
+	"crowfather/internal/espn"
 	"crowfather/internal/groupme"
 	"crowfather/internal/open_ai"
+	"crowfather/internal/reconciler"
 	"crowfather/internal/router"
+	"crowfather/internal/sleeper"
 	"fmt"
+	"time"
+
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
 	cfg, err := config.LoadConfig()
-
 	if err != nil {
 		fmt.Printf("Failed to load config: %v\n", err)
 		return
 	}
 
-	var repo open_ai.ThreadRepository
+	// Database — optional. Service runs in memory-only mode if unavailable.
+	var threadRepo open_ai.ThreadRepository
+	var metaRepo reconciler.MetadataRepository
 	dbSvc, err := database.ConnectDb()
 	if err != nil {
 		fmt.Printf("Database unavailable, running in memory-only mode: %v\n", err)
 	} else {
-		pgRepo := database.NewPgThreadRepository(dbSvc.DB())
-		if err := pgRepo.Migrate(context.Background()); err != nil {
-			fmt.Printf("Schema migration failed, running in memory-only mode: %v\n", err)
+		pgThread := database.NewPgThreadRepository(dbSvc.DB())
+		if err := pgThread.Migrate(context.Background()); err != nil {
+			fmt.Printf("Thread schema migration failed: %v\n", err)
 		} else {
-			repo = pgRepo
+			threadRepo = pgThread
+		}
+
+		pgMeta := database.NewPgMetadataRepository(dbSvc.DB())
+		if err := pgMeta.Migrate(context.Background()); err != nil {
+			fmt.Printf("Metadata schema migration failed: %v\n", err)
+		} else {
+			metaRepo = pgMeta
 		}
 	}
 
-	oai := open_ai.NewOpenAIService(cfg.OpenAI, repo)
+	oai := open_ai.NewOpenAIService(cfg.OpenAI, threadRepo)
 	gms := groupme.NewGroupMeService(cfg.GroupMe)
-	r, err := router.NewRouter(oai, gms, cfg)
 
+	// Reconciler — optional. Only constructed when SLEEPER_LEAGUE_IDS is set.
+	var rec *reconciler.Reconciler
+	if cfg.Reconciler != nil {
+		rec = reconciler.NewReconciler(
+			espn.NewESPNService(),
+			sleeper.NewSleeperService(),
+			oai,
+			metaRepo,
+			cfg.Reconciler.LeagueIDs,
+			cfg.Assistants.GroupMeAssistantID,
+			cfg.Reconciler.TransactionRounds,
+			cfg.Reconciler.CooldownMinutes,
+			cfg.Reconciler.ApprovedUsers,
+		)
+
+		// Startup trigger.
+		if cfg.Reconciler.OnStartup {
+			fmt.Println("Starting initial roster reconciliation...")
+			rec.Trigger("", nil)
+		}
+
+		// Periodic cron goroutine.
+		go func() {
+			ticker := time.NewTicker(cfg.Reconciler.Interval)
+			defer ticker.Stop()
+			for range ticker.C {
+				fmt.Println("Cron: triggering scheduled roster reconciliation")
+				rec.Trigger("", nil)
+			}
+		}()
+	}
+
+	r, err := router.NewRouter(oai, gms, rec, cfg)
 	if err != nil {
 		return
 	}

--- a/internal/open_ai/vector_store.go
+++ b/internal/open_ai/vector_store.go
@@ -1,0 +1,83 @@
+package open_ai
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/openai/openai-go"
+)
+
+// CreateVectorStore creates a new OpenAI vector store and returns its ID.
+func (oai *OpenAIService) CreateVectorStore(ctx context.Context, name string) (string, error) {
+	client := openai.NewClient(oai.Options...)
+	vs, err := client.VectorStores.New(ctx, openai.VectorStoreNewParams{
+		Name: openai.String(name),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create vector store: %w", err)
+	}
+	return vs.ID, nil
+}
+
+// UploadFilesToVectorStore uploads the provided documents to a vector store in a
+// single batch and polls until all files are processed.
+// docs is a map of filename → file content (Markdown bytes).
+func (oai *OpenAIService) UploadFilesToVectorStore(ctx context.Context, vsID string, docs map[string][]byte) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	client := openai.NewClient(oai.Options...)
+
+	fileParams := make([]openai.FileNewParams, 0, len(docs))
+	for _, content := range docs {
+		fileParams = append(fileParams, openai.FileNewParams{
+			File:    bytes.NewReader(content),
+			Purpose: openai.FilePurposeAssistants,
+		})
+	}
+
+	batch, err := client.VectorStores.FileBatches.UploadAndPoll(
+		ctx, vsID, fileParams, nil, 5000, oai.Options...,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to upload files to vector store: %w", err)
+	}
+
+	if batch.Status == "failed" {
+		return fmt.Errorf("vector store file batch failed: %d file(s) errored", batch.FileCounts.Failed)
+	}
+
+	return nil
+}
+
+// AttachVectorStoreToAssistant updates the assistant to use the given vector store
+// for file_search. It also ensures the file_search tool is enabled.
+func (oai *OpenAIService) AttachVectorStoreToAssistant(ctx context.Context, assistantID, vsID string) error {
+	client := openai.NewClient(oai.Options...)
+	_, err := client.Beta.Assistants.Update(ctx, assistantID, openai.BetaAssistantUpdateParams{
+		Tools: []openai.AssistantToolUnionParam{
+			{OfFileSearch: &openai.FileSearchToolParam{}},
+		},
+		ToolResources: openai.BetaAssistantUpdateParamsToolResources{
+			FileSearch: openai.BetaAssistantUpdateParamsToolResourcesFileSearch{
+				VectorStoreIDs: []string{vsID},
+			},
+		},
+	}, oai.Options...)
+	if err != nil {
+		return fmt.Errorf("failed to attach vector store %s to assistant %s: %w", vsID, assistantID, err)
+	}
+	return nil
+}
+
+// DeleteVectorStore deletes a vector store by ID.
+func (oai *OpenAIService) DeleteVectorStore(ctx context.Context, vsID string) error {
+	client := openai.NewClient(oai.Options...)
+	_, err := client.VectorStores.Delete(ctx, vsID, oai.Options...)
+	if err != nil {
+		return fmt.Errorf("failed to delete vector store %s: %w", vsID, err)
+	}
+	return nil
+}

--- a/internal/reconciler/document.go
+++ b/internal/reconciler/document.go
@@ -1,0 +1,241 @@
+package reconciler
+
+import (
+	"crowfather/internal/espn"
+	"crowfather/internal/sleeper"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// buildNFLTeamDoc generates a Markdown document for a single NFL team.
+func buildNFLTeamDoc(team espn.TeamWithRoster) []byte {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "# %s\n", team.Team.Name)
+	if team.Team.RecordSummary != "" {
+		fmt.Fprintf(&sb, "Record: %s", team.Team.RecordSummary)
+	}
+	if team.Team.SeasonSummary != "" {
+		fmt.Fprintf(&sb, " | Season: %s", team.Team.SeasonSummary)
+	}
+	if team.Team.StandingSummary != "" {
+		fmt.Fprintf(&sb, " | Standing: %s", team.Team.StandingSummary)
+	}
+	sb.WriteString("\n\n## Roster\n\n")
+	sb.WriteString("| Name | Position |\n")
+	sb.WriteString("|------|----------|\n")
+	for _, a := range team.Roster {
+		fmt.Fprintf(&sb, "| %s | %s |\n", a.DisplayName, a.Position)
+	}
+
+	return []byte(sb.String())
+}
+
+// leagueData holds resolved league information for document generation.
+type leagueData struct {
+	leagueID   string
+	leagueName string
+	rosters    []resolvedRoster
+	trades     []resolvedTrade
+}
+
+type resolvedRoster struct {
+	ownerName string
+	players   []resolvedPlayer
+}
+
+type resolvedPlayer struct {
+	name       string
+	position   string
+	nflTeam    string
+	nflRecord  string
+}
+
+type resolvedTrade struct {
+	timestamp time.Time
+	sides     []tradeSide
+}
+
+type tradeSide struct {
+	ownerName string
+	receives  []string // player names + draft picks
+}
+
+// buildFantasyLeagueDoc generates a Markdown document for a single Sleeper league.
+func buildFantasyLeagueDoc(ld leagueData) []byte {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "# Fantasy League: %s\n\n", ld.leagueName)
+
+	if len(ld.trades) > 0 {
+		sb.WriteString("## Recent Trades\n\n")
+		for _, t := range ld.trades {
+			sb.WriteString(fmt.Sprintf("**%s**\n", t.timestamp.Format("Jan 2, 2006")))
+			for _, side := range t.sides {
+				fmt.Fprintf(&sb, "- %s receives: %s\n", side.ownerName, strings.Join(side.receives, ", "))
+			}
+			sb.WriteString("\n")
+		}
+	}
+
+	for _, r := range ld.rosters {
+		fmt.Fprintf(&sb, "## Team: %s\n\n", r.ownerName)
+		sb.WriteString("| Player | Position | NFL Team | NFL Record |\n")
+		sb.WriteString("|--------|----------|----------|------------|\n")
+		for _, p := range r.players {
+			fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", p.name, p.position, p.nflTeam, p.nflRecord)
+		}
+		sb.WriteString("\n")
+	}
+
+	return []byte(sb.String())
+}
+
+// buildTradeSummary generates the GroupMe notification string for recent trades.
+func buildTradeSummary(leagues []leagueData) string {
+	var sb strings.Builder
+	sb.WriteString("Rosters refreshed!\n\n")
+
+	anyTrades := false
+	for _, ld := range leagues {
+		if len(ld.trades) == 0 {
+			continue
+		}
+		anyTrades = true
+		fmt.Fprintf(&sb, "Recent Trades - %s:\n", ld.leagueName)
+		for _, t := range ld.trades {
+			for i, side := range t.sides {
+				if i == 0 {
+					fmt.Fprintf(&sb, "  - %s", side.ownerName)
+				} else {
+					fmt.Fprintf(&sb, " <-> %s", side.ownerName)
+				}
+			}
+			sb.WriteString("\n")
+			for _, side := range t.sides {
+				fmt.Fprintf(&sb, "    %s gets: %s\n", side.ownerName, strings.Join(side.receives, ", "))
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	if !anyTrades {
+		sb.WriteString("No recent trades found.")
+	}
+
+	return sb.String()
+}
+
+// resolveLeague converts raw Sleeper data into a leagueData struct, cross-referencing
+// ESPN player data where possible.
+func resolveLeague(
+	leagueID string,
+	leagueName string,
+	rosters []sleeper.Roster,
+	users []sleeper.User,
+	players map[string]sleeper.SleeperPlayer,
+	transactions []sleeper.Transaction,
+	espnByName map[string]espn.TeamWithRoster,
+) leagueData {
+	// Build roster_id → owner name lookup
+	ownerByRosterID := make(map[int]string)
+	userByID := make(map[string]sleeper.User)
+	for _, u := range users {
+		userByID[u.UserID] = u
+	}
+	for _, r := range rosters {
+		if u, ok := userByID[r.OwnerID]; ok {
+			ownerByRosterID[r.RosterID] = u.DisplayName
+		} else {
+			ownerByRosterID[r.RosterID] = fmt.Sprintf("Team %d", r.RosterID)
+		}
+	}
+
+	// Resolve rosters
+	var resolved []resolvedRoster
+	for _, r := range rosters {
+		owner := ownerByRosterID[r.RosterID]
+		var rPlayers []resolvedPlayer
+		for _, pid := range r.Players {
+			sp, ok := players[pid]
+			if !ok {
+				continue
+			}
+			rp := resolvedPlayer{
+				name:     sp.FullName,
+				position: sp.Position,
+				nflTeam:  sp.Team,
+			}
+			// Cross-reference with ESPN for team record
+			if teamData, found := espnByName[normalizeTeam(sp.Team)]; found {
+				rp.nflTeam = teamData.Team.Name
+				rp.nflRecord = teamData.Team.RecordSummary
+			}
+			rPlayers = append(rPlayers, rp)
+		}
+		resolved = append(resolved, resolvedRoster{ownerName: owner, players: rPlayers})
+	}
+
+	// Resolve trades
+	var trades []resolvedTrade
+	for _, t := range transactions {
+		if t.Type != "trade" || t.Status != "complete" {
+			continue
+		}
+
+		// Group adds by the receiving roster
+		receives := make(map[int][]string)
+		for pid, rosterID := range t.Adds {
+			name := pid
+			if sp, ok := players[pid]; ok {
+				name = sp.FullName
+			}
+			receives[rosterID] = append(receives[rosterID], name)
+		}
+		// Add draft picks to the receiving owner
+		for _, pick := range t.DraftPicks {
+			pickStr := fmt.Sprintf("%s %s Round Pick", pick.Season, ordinal(pick.Round))
+			receives[pick.OwnerID] = append(receives[pick.OwnerID], pickStr)
+		}
+
+		var sides []tradeSide
+		for rosterID, items := range receives {
+			sides = append(sides, tradeSide{
+				ownerName: ownerByRosterID[rosterID],
+				receives:  items,
+			})
+		}
+
+		trades = append(trades, resolvedTrade{
+			timestamp: time.Unix(t.Created/1000, 0),
+			sides:     sides,
+		})
+	}
+
+	return leagueData{
+		leagueID:   leagueID,
+		leagueName: leagueName,
+		rosters:    resolved,
+		trades:     trades,
+	}
+}
+
+// normalizeTeam builds a lookup key from a Sleeper NFL team abbreviation.
+// ESPN team data is stored by abbreviation in the espnByName map.
+func normalizeTeam(abbrev string) string {
+	return strings.ToUpper(strings.TrimSpace(abbrev))
+}
+
+func ordinal(n int) string {
+	switch n {
+	case 1:
+		return "1st"
+	case 2:
+		return "2nd"
+	case 3:
+		return "3rd"
+	default:
+		return fmt.Sprintf("%dth", n)
+	}
+}

--- a/internal/reconciler/document_test.go
+++ b/internal/reconciler/document_test.go
@@ -1,0 +1,225 @@
+package reconciler
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"crowfather/internal/espn"
+	"crowfather/internal/sleeper"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildNFLTeamDoc_ContainsTeamInfo(t *testing.T) {
+	team := espn.TeamWithRoster{
+		Team: espn.Team{
+			TeamID:          "1",
+			Name:            "Kansas City Chiefs",
+			RecordSummary:   "15-2",
+			SeasonSummary:   "2024",
+			StandingSummary: "1st AFC West",
+		},
+		Roster: []espn.Athlete{
+			{DisplayName: "Patrick Mahomes", Position: "QB"},
+			{DisplayName: "Travis Kelce", Position: "TE"},
+		},
+	}
+
+	doc := string(buildNFLTeamDoc(team))
+	assert.Contains(t, doc, "# Kansas City Chiefs")
+	assert.Contains(t, doc, "15-2")
+	assert.Contains(t, doc, "2024")
+	assert.Contains(t, doc, "1st AFC West")
+	assert.Contains(t, doc, "Patrick Mahomes")
+	assert.Contains(t, doc, "QB")
+	assert.Contains(t, doc, "Travis Kelce")
+	assert.Contains(t, doc, "TE")
+}
+
+func TestBuildNFLTeamDoc_EmptyRoster(t *testing.T) {
+	team := espn.TeamWithRoster{
+		Team: espn.Team{Name: "Test Team"},
+	}
+	doc := string(buildNFLTeamDoc(team))
+	assert.Contains(t, doc, "# Test Team")
+	assert.Contains(t, doc, "## Roster")
+}
+
+func TestBuildFantasyLeagueDoc_ContainsRosters(t *testing.T) {
+	ld := leagueData{
+		leagueID:   "league1",
+		leagueName: "Main Dynasty",
+		rosters: []resolvedRoster{
+			{
+				ownerName: "JohnFantasy",
+				players: []resolvedPlayer{
+					{name: "Patrick Mahomes", position: "QB", nflTeam: "Kansas City Chiefs", nflRecord: "15-2"},
+				},
+			},
+		},
+	}
+
+	doc := string(buildFantasyLeagueDoc(ld))
+	assert.Contains(t, doc, "# Fantasy League: Main Dynasty")
+	assert.Contains(t, doc, "## Team: JohnFantasy")
+	assert.Contains(t, doc, "Patrick Mahomes")
+	assert.Contains(t, doc, "Kansas City Chiefs")
+	assert.Contains(t, doc, "15-2")
+}
+
+func TestBuildFantasyLeagueDoc_IncludesTrades(t *testing.T) {
+	ld := leagueData{
+		leagueID:   "l1",
+		leagueName: "Test League",
+		trades: []resolvedTrade{
+			{
+				timestamp: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				sides: []tradeSide{
+					{ownerName: "Alice", receives: []string{"Mahomes", "2026 1st Round Pick"}},
+					{ownerName: "Bob", receives: []string{"Kelce"}},
+				},
+			},
+		},
+	}
+
+	doc := string(buildFantasyLeagueDoc(ld))
+	assert.Contains(t, doc, "## Recent Trades")
+	assert.Contains(t, doc, "Alice")
+	assert.Contains(t, doc, "Mahomes")
+	assert.Contains(t, doc, "2026 1st Round Pick")
+	assert.Contains(t, doc, "Bob")
+	assert.Contains(t, doc, "Kelce")
+}
+
+func TestBuildTradeSummary_NoTrades(t *testing.T) {
+	leagues := []leagueData{
+		{leagueName: "League A", trades: nil},
+	}
+	summary := buildTradeSummary(leagues)
+	assert.Contains(t, summary, "Rosters refreshed!")
+	assert.Contains(t, summary, "No recent trades found.")
+}
+
+func TestBuildTradeSummary_WithTrades(t *testing.T) {
+	leagues := []leagueData{
+		{
+			leagueName: "Dynasty League",
+			trades: []resolvedTrade{
+				{
+					sides: []tradeSide{
+						{ownerName: "Alice", receives: []string{"Mahomes"}},
+						{ownerName: "Bob", receives: []string{"Kelce"}},
+					},
+				},
+			},
+		},
+	}
+	summary := buildTradeSummary(leagues)
+	assert.Contains(t, summary, "Rosters refreshed!")
+	assert.Contains(t, summary, "Dynasty League")
+	assert.Contains(t, summary, "Alice")
+	assert.Contains(t, summary, "Bob")
+	assert.NotContains(t, summary, "No recent trades found.")
+}
+
+func TestResolveLeague_MapsOwnerNames(t *testing.T) {
+	rosters := []sleeper.Roster{
+		{RosterID: 1, OwnerID: "u1", Players: []string{"p1"}},
+	}
+	users := []sleeper.User{
+		{UserID: "u1", DisplayName: "JohnFantasy"},
+	}
+	players := map[string]sleeper.SleeperPlayer{
+		"p1": {PlayerID: "p1", FullName: "Patrick Mahomes", Position: "QB", Team: "KC"},
+	}
+
+	ld := resolveLeague("l1", "Test League", rosters, users, players, nil, nil)
+	require.Len(t, ld.rosters, 1)
+	assert.Equal(t, "JohnFantasy", ld.rosters[0].ownerName)
+	require.Len(t, ld.rosters[0].players, 1)
+	assert.Equal(t, "Patrick Mahomes", ld.rosters[0].players[0].name)
+}
+
+func TestResolveLeague_FallbackOwnerName(t *testing.T) {
+	// Roster with no matching user → fallback to "Team N"
+	rosters := []sleeper.Roster{
+		{RosterID: 7, OwnerID: "unknown", Players: nil},
+	}
+	ld := resolveLeague("l1", "L", rosters, nil, nil, nil, nil)
+	require.Len(t, ld.rosters, 1)
+	assert.Equal(t, "Team 7", ld.rosters[0].ownerName)
+}
+
+func TestResolveLeague_CrossReferencesESPN(t *testing.T) {
+	rosters := []sleeper.Roster{
+		{RosterID: 1, OwnerID: "u1", Players: []string{"p1"}},
+	}
+	users := []sleeper.User{{UserID: "u1", DisplayName: "Alice"}}
+	players := map[string]sleeper.SleeperPlayer{
+		"p1": {PlayerID: "p1", FullName: "Patrick Mahomes", Position: "QB", Team: "KC"},
+	}
+	espnByName := map[string]espn.TeamWithRoster{
+		"KC": {
+			Team:   espn.Team{Name: "Kansas City Chiefs", RecordSummary: "15-2"},
+			Roster: []espn.Athlete{{DisplayName: "Patrick Mahomes", Position: "QB"}},
+		},
+	}
+
+	ld := resolveLeague("l1", "L", rosters, users, players, nil, espnByName)
+	require.Len(t, ld.rosters[0].players, 1)
+	p := ld.rosters[0].players[0]
+	assert.Equal(t, "Kansas City Chiefs", p.nflTeam)
+	assert.Equal(t, "15-2", p.nflRecord)
+}
+
+func TestResolveLeague_ResolvesCompletedTrades(t *testing.T) {
+	rosters := []sleeper.Roster{
+		{RosterID: 1, OwnerID: "u1"},
+		{RosterID: 2, OwnerID: "u2"},
+	}
+	users := []sleeper.User{
+		{UserID: "u1", DisplayName: "Alice"},
+		{UserID: "u2", DisplayName: "Bob"},
+	}
+	transactions := []sleeper.Transaction{
+		{
+			TransactionID: "t1",
+			Type:          "trade",
+			Status:        "complete",
+			Adds:          map[string]int{"p1": 2}, // Bob receives p1
+			DraftPicks:    []sleeper.TradedPick{{Season: "2026", Round: 1, OwnerID: 1}}, // Alice receives pick
+			Created:       time.Now().Unix() * 1000,
+		},
+	}
+	players := map[string]sleeper.SleeperPlayer{
+		"p1": {FullName: "Patrick Mahomes"},
+	}
+
+	ld := resolveLeague("l1", "L", rosters, users, players, transactions, nil)
+	require.Len(t, ld.trades, 1)
+
+	// Collect all items received across sides
+	var allReceived []string
+	for _, side := range ld.trades[0].sides {
+		allReceived = append(allReceived, side.receives...)
+	}
+	assert.True(t, func() bool {
+		for _, s := range allReceived {
+			if strings.Contains(s, "Mahomes") {
+				return true
+			}
+		}
+		return false
+	}(), "expected Mahomes in received items")
+}
+
+func TestOrdinal(t *testing.T) {
+	cases := map[int]string{
+		1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 10: "10th",
+	}
+	for n, want := range cases {
+		assert.Equal(t, want, ordinal(n))
+	}
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -1,0 +1,239 @@
+package reconciler
+
+import (
+	"context"
+	"crowfather/internal/espn"
+	"crowfather/internal/open_ai"
+	"crowfather/internal/sleeper"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const vectorStoreName = "crowfather-sports-data"
+const vectorStoreIDKey = "vector_store_id"
+
+// MetadataRepository is the persistence contract for key/value metadata.
+// The concrete implementation lives in the database package.
+type MetadataRepository interface {
+	GetMetadata(ctx context.Context, key string) (string, error)
+	SetMetadata(ctx context.Context, key, value string) error
+}
+
+// Reconciler orchestrates fetching ESPN + Sleeper data, generating documents,
+// and uploading them to an OpenAI vector store.
+type Reconciler struct {
+	espn          *espn.ESPNService
+	sleeper       *sleeper.SleeperService
+	oai           *open_ai.OpenAIService
+	db            MetadataRepository
+	leagueIDs     []string
+	assistantID   string
+	transRounds   int
+	approvedUsers map[string]bool
+
+	mu        sync.Mutex
+	running   bool
+	lastRunAt time.Time
+	cooldown  time.Duration
+}
+
+func NewReconciler(
+	espnSvc *espn.ESPNService,
+	sleeperSvc *sleeper.SleeperService,
+	oai *open_ai.OpenAIService,
+	db MetadataRepository,
+	leagueIDs []string,
+	assistantID string,
+	transRounds int,
+	cooldown time.Duration,
+	approvedUsers []string,
+) *Reconciler {
+	approved := make(map[string]bool, len(approvedUsers))
+	for _, u := range approvedUsers {
+		approved[u] = true
+	}
+
+	return &Reconciler{
+		espn:          espnSvc,
+		sleeper:       sleeperSvc,
+		oai:           oai,
+		db:            db,
+		leagueIDs:     leagueIDs,
+		assistantID:   assistantID,
+		transRounds:   transRounds,
+		cooldown:      cooldown,
+		approvedUsers: approved,
+	}
+}
+
+// Trigger attempts to start a reconciliation run. senderUserID is the GroupMe
+// user_id of the person triggering via chat, or "" for HTTP/cron/startup triggers.
+// notify is an optional callback called with the trade summary when the run completes.
+// Returns (true, "") if the run was started, or (false, reason) if blocked.
+func (r *Reconciler) Trigger(senderUserID string, notify func(string)) (triggered bool, reason string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Access control: only applies to GroupMe triggers with a non-empty user ID.
+	if senderUserID != "" && len(r.approvedUsers) > 0 {
+		if !r.approvedUsers[senderUserID] {
+			return false, "You're not authorized to trigger a roster refresh."
+		}
+	}
+
+	// Cooldown check.
+	if !r.lastRunAt.IsZero() && time.Since(r.lastRunAt) < r.cooldown {
+		remaining := (r.cooldown - time.Since(r.lastRunAt)).Round(time.Minute)
+		return false, fmt.Sprintf("Roster data was just refreshed. Try again in %v.", remaining)
+	}
+
+	// In-flight guard.
+	if r.running {
+		return false, "A roster refresh is already in progress."
+	}
+
+	r.running = true
+	go func() {
+		var summary string
+		defer func() {
+			if rec := recover(); rec != nil {
+				fmt.Printf("reconciler: recovered from panic: %v\n", rec)
+				summary = fmt.Sprintf("Roster refresh failed unexpectedly: %v", rec)
+				if notify != nil {
+					notify(summary)
+				}
+			}
+			r.mu.Lock()
+			r.running = false
+			r.lastRunAt = time.Now()
+			r.mu.Unlock()
+		}()
+		var err error
+		summary, err = r.run(context.Background())
+		if err != nil {
+			fmt.Printf("reconciler: run failed: %v\n", err)
+			summary = fmt.Sprintf("Roster refresh failed: %v", err)
+		}
+		if notify != nil {
+			notify(summary)
+		}
+	}()
+
+	return true, ""
+}
+
+// run performs the full reconciliation cycle and returns a trade summary string.
+func (r *Reconciler) run(ctx context.Context) (string, error) {
+	fmt.Println("reconciler: starting data fetch")
+
+	// 1. Fetch ESPN rosters.
+	nflTeams, err := r.espn.FetchAllTeamRosters(ctx)
+	if err != nil {
+		return "", fmt.Errorf("espn fetch failed: %w", err)
+	}
+	fmt.Printf("reconciler: fetched %d NFL teams from ESPN\n", len(nflTeams))
+
+	// Build ESPN lookup map: normalized team abbreviation → TeamWithRoster.
+	// ESPN doesn't use abbreviations in its API; we build a name-based lookup.
+	espnByName := make(map[string]espn.TeamWithRoster, len(nflTeams))
+	for _, t := range nflTeams {
+		espnByName[normalizeTeam(t.Team.Name)] = t
+	}
+
+	// 2. Fetch Sleeper all-players (large, in-memory only during this run).
+	sleeperPlayers, err := r.sleeper.FetchAllPlayers(ctx)
+	if err != nil {
+		return "", fmt.Errorf("sleeper players fetch failed: %w", err)
+	}
+	fmt.Printf("reconciler: fetched %d Sleeper players\n", len(sleeperPlayers))
+
+	// 3. Per-league: fetch rosters, users, transactions.
+	var leagues []leagueData
+	for _, lid := range r.leagueIDs {
+		league, err := r.fetchLeagueData(ctx, lid, sleeperPlayers, espnByName)
+		if err != nil {
+			fmt.Printf("reconciler: skipping league %s: %v\n", lid, err)
+			continue
+		}
+		leagues = append(leagues, league)
+	}
+
+	// 4. Generate documents.
+	docs := make(map[string][]byte)
+	for _, team := range nflTeams {
+		key := fmt.Sprintf("nfl_team_%s.md", team.Team.TeamID)
+		docs[key] = buildNFLTeamDoc(team)
+	}
+	for _, ld := range leagues {
+		key := fmt.Sprintf("fantasy_league_%s.md", ld.leagueID)
+		docs[key] = buildFantasyLeagueDoc(ld)
+	}
+	fmt.Printf("reconciler: generated %d documents\n", len(docs))
+
+	// 5. Create new vector store.
+	vsID, err := r.oai.CreateVectorStore(ctx, vectorStoreName)
+	if err != nil {
+		return "", fmt.Errorf("vector store creation failed: %w", err)
+	}
+	fmt.Printf("reconciler: created vector store %s\n", vsID)
+
+	// 6. Upload documents.
+	if err := r.oai.UploadFilesToVectorStore(ctx, vsID, docs); err != nil {
+		return "", fmt.Errorf("vector store upload failed: %w", err)
+	}
+	fmt.Println("reconciler: files uploaded to vector store")
+
+	// 7. Attach vector store to GroupMe assistant.
+	if err := r.oai.AttachVectorStoreToAssistant(ctx, r.assistantID, vsID); err != nil {
+		return "", fmt.Errorf("vector store attachment failed: %w", err)
+	}
+	fmt.Printf("reconciler: attached vector store to assistant %s\n", r.assistantID)
+
+	// 8. Delete old vector store (if any).
+	if r.db != nil {
+		oldVsID, _ := r.db.GetMetadata(ctx, vectorStoreIDKey)
+		if oldVsID != "" && oldVsID != vsID {
+			if err := r.oai.DeleteVectorStore(ctx, oldVsID); err != nil {
+				fmt.Printf("reconciler: failed to delete old vector store %s: %v\n", oldVsID, err)
+			}
+		}
+
+		// 9. Persist new vector store ID.
+		if err := r.db.SetMetadata(ctx, vectorStoreIDKey, vsID); err != nil {
+			fmt.Printf("reconciler: failed to persist vector store ID: %v\n", err)
+		}
+	}
+
+	return buildTradeSummary(leagues), nil
+}
+
+func (r *Reconciler) fetchLeagueData(
+	ctx context.Context,
+	leagueID string,
+	sleeperPlayers map[string]sleeper.SleeperPlayer,
+	espnByName map[string]espn.TeamWithRoster,
+) (leagueData, error) {
+	league, err := r.sleeper.FetchLeague(ctx, leagueID)
+	if err != nil {
+		return leagueData{}, err
+	}
+
+	rosters, err := r.sleeper.FetchLeagueRosters(ctx, leagueID)
+	if err != nil {
+		return leagueData{}, err
+	}
+
+	users, err := r.sleeper.FetchLeagueUsers(ctx, leagueID)
+	if err != nil {
+		return leagueData{}, err
+	}
+
+	transactions, err := r.sleeper.FetchRecentTransactions(ctx, leagueID, r.transRounds)
+	if err != nil {
+		fmt.Printf("reconciler: failed to fetch transactions for league %s: %v\n", leagueID, err)
+		transactions = nil // non-fatal
+	}
+
+	return resolveLeague(leagueID, league.Name, rosters, users, sleeperPlayers, transactions, espnByName), nil
+}

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -1,0 +1,104 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newGuardTestReconciler() *Reconciler {
+	return &Reconciler{cooldown: 0}
+}
+
+func TestTrigger_UnauthorizedUser(t *testing.T) {
+	r := newGuardTestReconciler()
+	r.approvedUsers = map[string]bool{"allowed": true}
+
+	triggered, reason := r.Trigger("stranger", nil)
+	assert.False(t, triggered)
+	assert.Contains(t, reason, "not authorized")
+}
+
+func TestTrigger_ApprovedUserAllowed(t *testing.T) {
+	r := newGuardTestReconciler()
+	r.approvedUsers = map[string]bool{"allowed": true}
+
+	done := make(chan string, 1)
+	triggered, reason := r.Trigger("allowed", func(s string) { done <- s })
+	assert.True(t, triggered)
+	assert.Empty(t, reason)
+	<-done // wait for goroutine to finish
+}
+
+func TestTrigger_EmptySenderBypassesAccessControl(t *testing.T) {
+	r := newGuardTestReconciler()
+	r.approvedUsers = map[string]bool{"allowed": true}
+
+	done := make(chan string, 1)
+	triggered, reason := r.Trigger("", func(s string) { done <- s })
+	assert.True(t, triggered)
+	assert.Empty(t, reason)
+	<-done
+}
+
+func TestTrigger_NoApprovedListAllowsAnyone(t *testing.T) {
+	r := newGuardTestReconciler()
+	// approvedUsers is nil/empty — anyone can trigger
+
+	done := make(chan string, 1)
+	triggered, _ := r.Trigger("random-user", func(s string) { done <- s })
+	assert.True(t, triggered)
+	<-done
+}
+
+func TestTrigger_CooldownBlocks(t *testing.T) {
+	r := &Reconciler{
+		cooldown:  time.Hour,
+		lastRunAt: time.Now(),
+	}
+
+	triggered, reason := r.Trigger("", nil)
+	assert.False(t, triggered)
+	assert.Contains(t, reason, "just refreshed")
+}
+
+func TestTrigger_InFlightBlocks(t *testing.T) {
+	r := newGuardTestReconciler()
+	r.running = true
+
+	triggered, reason := r.Trigger("", nil)
+	assert.False(t, triggered)
+	assert.Contains(t, reason, "already in progress")
+}
+
+func TestTrigger_NotifyCalledAfterRun(t *testing.T) {
+	r := newGuardTestReconciler()
+	done := make(chan string, 1)
+
+	triggered, _ := r.Trigger("", func(s string) { done <- s })
+	require.True(t, triggered)
+
+	select {
+	case summary := <-done:
+		assert.NotEmpty(t, summary)
+	case <-time.After(5 * time.Second):
+		t.Error("notify was not called within 5s")
+	}
+}
+
+func TestTrigger_SetsRunningFalseAfterCompletion(t *testing.T) {
+	r := newGuardTestReconciler()
+	done := make(chan string, 1)
+
+	triggered, _ := r.Trigger("", func(s string) { done <- s })
+	require.True(t, triggered)
+
+	<-done
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.False(t, r.running)
+	assert.False(t, r.lastRunAt.IsZero())
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,30 +7,32 @@ import (
 	"crowfather/internal/handlers/message_handler"
 	"crowfather/internal/handlers/test_handler"
 	"crowfather/internal/open_ai"
-	"github.com/gin-gonic/gin"
+	"crowfather/internal/reconciler"
+	"fmt"
 	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 type Router struct {
 	oai             *open_ai.OpenAIService
 	gms             *groupme.GroupMeService
+	rec             *reconciler.Reconciler // nil if reconciler is not configured
 	messageHandler  func(groupme.Message, *open_ai.OpenAIService, *groupme.GroupMeService, string) (string, error)
 	testHandler     func(string, *open_ai.OpenAIService, string) (string, error)
 	meltdownHandler func(string, *open_ai.OpenAIService, string) (string, error)
 	config          *config.Config
 }
 
-func NewRouter(oai *open_ai.OpenAIService, gms *groupme.GroupMeService, config *config.Config) (*Router, error) {
-	messageHandler := message_handler.Handle
-	testHandler := test_handler.Handle
-	meltdownHandler := meltdown_handler.Handle
-
+func NewRouter(oai *open_ai.OpenAIService, gms *groupme.GroupMeService, rec *reconciler.Reconciler, config *config.Config) (*Router, error) {
 	return &Router{
-		messageHandler:  messageHandler,
-		testHandler:     testHandler,
-		meltdownHandler: meltdownHandler,
+		messageHandler:  message_handler.Handle,
+		testHandler:     test_handler.Handle,
+		meltdownHandler: meltdown_handler.Handle,
 		oai:             oai,
 		gms:             gms,
+		rec:             rec,
 		config:          config,
 	}, nil
 }
@@ -43,6 +45,7 @@ func (r *Router) RegisterRoutes(engine *gin.Engine) {
 	base := engine.Group("/")
 	base.Use(AuthMiddleware(r.config.Auth.APIKey))
 	base.POST("/test", r.processTestMessage)
+	base.POST("/refresh", r.handleRefresh)
 }
 
 func (r *Router) handlePing(c *gin.Context) {
@@ -52,12 +55,23 @@ func (r *Router) handlePing(c *gin.Context) {
 }
 
 func (r *Router) processGroupMeMessage(c *gin.Context) {
-	var groupmeMessage groupme.Message
+	var msg groupme.Message
 
-	if err := c.BindJSON(&groupmeMessage); err != nil {
+	if err := c.BindJSON(&msg); err != nil {
 		return
 	}
-	response, err := r.messageHandler(groupmeMessage, r.oai, r.gms, r.config.Assistants.GroupMeAssistantID)
+
+	// Check for the GroupMe refresh trigger before routing to OpenAI.
+	if r.rec != nil && isRefreshTrigger(msg.Text) {
+		reply := r.handleGroupMeRefresh(msg)
+		if err := r.gms.SendRawMessage(reply); err != nil {
+			fmt.Printf("router: failed to send refresh reply: %v\n", err)
+		}
+		c.JSON(http.StatusOK, gin.H{})
+		return
+	}
+
+	response, err := r.messageHandler(msg, r.oai, r.gms, r.config.Assistants.GroupMeAssistantID)
 
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -115,6 +129,44 @@ func (r *Router) processMeltdownMessage(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"response": response,
 	})
+}
+
+// handleRefresh is the HTTP-triggered reconciliation endpoint (POST /refresh).
+// Protected by API key middleware. Returns 202 immediately; run is asynchronous.
+func (r *Router) handleRefresh(c *gin.Context) {
+	if r.rec == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "reconciler not configured"})
+		return
+	}
+
+	triggered, reason := r.rec.Trigger("", nil)
+	if !triggered {
+		c.JSON(http.StatusConflict, gin.H{"error": reason})
+		return
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{"status": "refresh started"})
+}
+
+// handleGroupMeRefresh processes the GroupMe refresh trigger keyword.
+// It sends an immediate acknowledgement and the notify callback posts the result.
+func (r *Router) handleGroupMeRefresh(msg groupme.Message) string {
+	notify := func(summary string) {
+		if err := r.gms.SendRawMessage(summary); err != nil {
+			fmt.Printf("router: failed to send refresh summary: %v\n", err)
+		}
+	}
+
+	triggered, reason := r.rec.Trigger(msg.UserId, notify)
+	if triggered {
+		return fmt.Sprintf("@%s On it! I'll post an update when the roster refresh is done.", msg.Name)
+	}
+	return fmt.Sprintf("@%s %s", msg.Name, reason)
+}
+
+// isRefreshTrigger returns true if the message text contains the refresh keyword.
+func isRefreshTrigger(text string) bool {
+	return strings.Contains(strings.ToLower(text), "hey crowfather refresh")
 }
 
 func AuthMiddleware(apiKey string) gin.HandlerFunc {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,43 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestIsRefreshTrigger(t *testing.T) {
+	cases := []struct {
+		text    string
+		want    bool
+	}{
+		{"hey crowfather refresh", true},
+		{"HEY CROWFATHER REFRESH", true},
+		{"Hey Crowfather Refresh the rosters", true},
+		{"please hey crowfather refresh now", true},
+		{"hey crowfather, what's up?", false},
+		{"refresh the rosters", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, isRefreshTrigger(tc.text), "input: %q", tc.text)
+	}
+}
+
+func TestHandleRefresh_NilReconciler_Returns503(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodPost, "/refresh", nil)
+
+	r := &Router{rec: nil}
+	r.handleRefresh(c)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}

--- a/internal/sleeper/sleeper.go
+++ b/internal/sleeper/sleeper.go
@@ -1,1 +1,101 @@
 package sleeper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const defaultBaseURL = "https://api.sleeper.app/v1"
+
+type SleeperService struct {
+	client  *http.Client
+	baseURL string
+}
+
+func NewSleeperService() *SleeperService {
+	return &SleeperService{
+		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL: defaultBaseURL,
+	}
+}
+
+// FetchAllPlayers fetches the full NFL player map from Sleeper (~5MB).
+// Returns a map keyed by Sleeper player ID for fast lookup.
+func (s *SleeperService) FetchAllPlayers(ctx context.Context) (map[string]SleeperPlayer, error) {
+	var players map[string]SleeperPlayer
+	if err := s.get(ctx, "/players/nfl", &players); err != nil {
+		return nil, fmt.Errorf("failed to fetch Sleeper players: %w", err)
+	}
+	return players, nil
+}
+
+// FetchLeague fetches basic league metadata.
+func (s *SleeperService) FetchLeague(ctx context.Context, leagueID string) (*League, error) {
+	var league League
+	if err := s.get(ctx, fmt.Sprintf("/league/%s", leagueID), &league); err != nil {
+		return nil, fmt.Errorf("failed to fetch league %s: %w", leagueID, err)
+	}
+	return &league, nil
+}
+
+// FetchLeagueRosters fetches all fantasy rosters for a league.
+func (s *SleeperService) FetchLeagueRosters(ctx context.Context, leagueID string) ([]Roster, error) {
+	var rosters []Roster
+	if err := s.get(ctx, fmt.Sprintf("/league/%s/rosters", leagueID), &rosters); err != nil {
+		return nil, fmt.Errorf("failed to fetch rosters for league %s: %w", leagueID, err)
+	}
+	return rosters, nil
+}
+
+// FetchLeagueUsers fetches all users in a league.
+func (s *SleeperService) FetchLeagueUsers(ctx context.Context, leagueID string) ([]User, error) {
+	var users []User
+	if err := s.get(ctx, fmt.Sprintf("/league/%s/users", leagueID), &users); err != nil {
+		return nil, fmt.Errorf("failed to fetch users for league %s: %w", leagueID, err)
+	}
+	return users, nil
+}
+
+// FetchRecentTransactions fetches completed trade transactions for a league,
+// paginating through rounds 1..maxRounds (or until an empty page is returned).
+// Only completed trades are returned.
+func (s *SleeperService) FetchRecentTransactions(ctx context.Context, leagueID string, maxRounds int) ([]Transaction, error) {
+	var all []Transaction
+	for round := 1; round <= maxRounds; round++ {
+		var page []Transaction
+		if err := s.get(ctx, fmt.Sprintf("/league/%s/transactions/%d", leagueID, round), &page); err != nil {
+			return nil, fmt.Errorf("failed to fetch transactions round %d for league %s: %w", round, leagueID, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, t := range page {
+			if t.Type == "trade" && t.Status == "complete" {
+				all = append(all, t)
+			}
+		}
+	}
+	return all, nil
+}
+
+func (s *SleeperService) get(ctx context.Context, path string, out interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/sleeper/sleeper_struct.go
+++ b/internal/sleeper/sleeper_struct.go
@@ -1,0 +1,42 @@
+package sleeper
+
+type SleeperPlayer struct {
+	PlayerID string `json:"player_id"`
+	FullName string `json:"full_name"`
+	Position string `json:"position"`
+	Team     string `json:"team"` // NFL team abbreviation, e.g. "KC"
+}
+
+type Roster struct {
+	RosterID int      `json:"roster_id"`
+	OwnerID  string   `json:"owner_id"`
+	Players  []string `json:"players"` // Sleeper player IDs
+}
+
+type User struct {
+	UserID      string `json:"user_id"`
+	DisplayName string `json:"display_name"`
+}
+
+type League struct {
+	LeagueID string `json:"league_id"`
+	Name     string `json:"name"`
+}
+
+type Transaction struct {
+	TransactionID string         `json:"transaction_id"`
+	Type          string         `json:"type"`   // "trade", "waiver", "free_agent"
+	Status        string         `json:"status"` // "complete", "pending", "cancelled"
+	Adds          map[string]int `json:"adds"`   // player_id → roster_id receiving
+	Drops         map[string]int `json:"drops"`  // player_id → roster_id dropping
+	DraftPicks    []TradedPick   `json:"draft_picks"`
+	RosterIDs     []int          `json:"roster_ids"`
+	Created       int64          `json:"created"`
+}
+
+type TradedPick struct {
+	Season          string `json:"season"`
+	Round           int    `json:"round"`
+	OwnerID         int    `json:"owner_id"`
+	PreviousOwnerID int    `json:"previous_owner_id"`
+}

--- a/internal/sleeper/sleeper_test.go
+++ b/internal/sleeper/sleeper_test.go
@@ -1,0 +1,141 @@
+package sleeper
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSleeper(server *httptest.Server) *SleeperService {
+	return &SleeperService{client: server.Client(), baseURL: server.URL}
+}
+
+func TestFetchAllPlayers(t *testing.T) {
+	players := map[string]SleeperPlayer{
+		"1234": {PlayerID: "1234", FullName: "Patrick Mahomes", Position: "QB", Team: "KC"},
+		"5678": {PlayerID: "5678", FullName: "Travis Kelce", Position: "TE", Team: "KC"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/players/nfl", r.URL.Path)
+		json.NewEncoder(w).Encode(players)
+	}))
+	defer server.Close()
+
+	got, err := newTestSleeper(server).FetchAllPlayers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "Patrick Mahomes", got["1234"].FullName)
+}
+
+func TestFetchLeagueRosters(t *testing.T) {
+	rosters := []Roster{
+		{RosterID: 1, OwnerID: "user1", Players: []string{"1234", "5678"}},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/league/myLeague/rosters", r.URL.Path)
+		json.NewEncoder(w).Encode(rosters)
+	}))
+	defer server.Close()
+
+	got, err := newTestSleeper(server).FetchLeagueRosters(context.Background(), "myLeague")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, []string{"1234", "5678"}, got[0].Players)
+}
+
+func TestFetchLeagueUsers(t *testing.T) {
+	users := []User{
+		{UserID: "user1", DisplayName: "JohnFantasy"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/league/myLeague/users", r.URL.Path)
+		json.NewEncoder(w).Encode(users)
+	}))
+	defer server.Close()
+
+	got, err := newTestSleeper(server).FetchLeagueUsers(context.Background(), "myLeague")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "JohnFantasy", got[0].DisplayName)
+}
+
+func TestFetchRecentTransactions_ReturnsTrades(t *testing.T) {
+	txs := []Transaction{
+		{TransactionID: "t1", Type: "trade", Status: "complete", RosterIDs: []int{1, 2}},
+		{TransactionID: "t2", Type: "waiver", Status: "complete"},   // should be filtered out
+		{TransactionID: "t3", Type: "trade", Status: "pending"},     // should be filtered out
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/1") {
+			json.NewEncoder(w).Encode(txs)
+			return
+		}
+		json.NewEncoder(w).Encode([]Transaction{}) // round 2 empty → stop
+	}))
+	defer server.Close()
+
+	got, err := newTestSleeper(server).FetchRecentTransactions(context.Background(), "league1", 3)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only completed trades should be returned")
+	assert.Equal(t, "t1", got[0].TransactionID)
+}
+
+func TestFetchRecentTransactions_StopsAtEmptyPage(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if strings.HasSuffix(r.URL.Path, "/1") {
+			json.NewEncoder(w).Encode([]Transaction{
+				{TransactionID: "t1", Type: "trade", Status: "complete"},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode([]Transaction{}) // empty on round 2
+	}))
+	defer server.Close()
+
+	_, err := newTestSleeper(server).FetchRecentTransactions(context.Background(), "league1", 5)
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "should stop after the empty page, not fetch all 5 rounds")
+}
+
+func TestFetchRecentTransactions_IncludesDraftPicks(t *testing.T) {
+	txs := []Transaction{{
+		TransactionID: "t1",
+		Type:          "trade",
+		Status:        "complete",
+		DraftPicks: []TradedPick{
+			{Season: "2026", Round: 1, OwnerID: 2, PreviousOwnerID: 1},
+		},
+	}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/1") {
+			json.NewEncoder(w).Encode(txs)
+			return
+		}
+		json.NewEncoder(w).Encode([]Transaction{})
+	}))
+	defer server.Close()
+
+	got, err := newTestSleeper(server).FetchRecentTransactions(context.Background(), "league1", 2)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Len(t, got[0].DraftPicks, 1)
+	assert.Equal(t, "2026", got[0].DraftPicks[0].Season)
+}
+
+func TestFetchLeague_ErrorOnNonOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := newTestSleeper(server).FetchLeague(context.Background(), "bad")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
…ctor store

Implements full pipeline: fetch live NFL roster/team data from ESPN API and fantasy league data from Sleeper API, reconcile into Markdown documents, and upload them to an OpenAI vector store attached to the GroupMe assistant so it can answer questions with current player, team, and trade data.

## New packages
- internal/espn/: ESPNService with concurrent 32-team roster fetch (goroutines + WaitGroup + channels). Structs copied and extended from example-poller pattern. Panic recovery added to per-team goroutines for resilience.
- internal/sleeper/: SleeperService fetching /players/nfl (5MB), league rosters, users, and paginated transactions. Filters for completed trades only.
- internal/reconciler/: Reconciler.Trigger() enforces access control (RECONCILE_APPROVED_USERS allowlist), cooldown timer, and in-flight guard via mutex before launching run() in a background goroutine. Panic recovery ensures the goroutine never crashes the server. Document generation produces per-team and per-league Markdown files with ESPN/Sleeper cross-reference by name+team. Trade summaries are included in league docs and sent to GroupMe on completion.
- internal/open_ai/vector_store.go: CreateVectorStore, UploadFilesToVectorStore (batch upload with polling), AttachVectorStoreToAssistant, DeleteVectorStore using openai-go SDK with atomic swap lifecycle (create → attach → delete old).
- internal/database/metadata_repository.go: PgMetadataRepository with key/value metadata table for persisting the active vector store ID across restarts.

## Modified files
- internal/config/config.go: ReconcilerConfig struct with loadReconcilerConfig() (returns nil if SLEEPER_LEAGUE_IDS unset, graceful degradation). New env vars: SLEEPER_LEAGUE_IDS, RECONCILE_ON_STARTUP, RECONCILE_INTERVAL_HOURS, RECONCILE_COOLDOWN_MINUTES, RECONCILE_APPROVED_USERS, RECONCILE_TRANSACTION_ROUNDS.
- internal/groupme/groupme.go: SendRawMessage() for bot-initiated messages (reconciliation summaries, trade notifications) without @mention prefix.
- internal/router/router.go: POST /refresh endpoint (API-key protected, 202/409/503). isRefreshTrigger() check in processGroupMeMessage for "hey crowfather refresh" keyword (case-insensitive) before OpenAI flow.
- internal/main.go: Wires ESPN, Sleeper, metadata repo, and Reconciler. Startup trigger (RECONCILE_ON_STARTUP=true by default) and weekly cron goroutine.

## Tests
Tests added for all new code: ESPN httptest-based roster fetch, Sleeper httptest- based player/roster/user/transaction fetch with pagination, ReconcilerConfig env var loading and defaults, GroupMe SendRawMessage (TLS test server), Reconciler Trigger() guard paths (access control, cooldown, in-flight, notify callback), document generation pure functions (buildNFLTeamDoc, buildFantasyLeagueDoc, buildTradeSummary, resolveLeague, ordinal), and router isRefreshTrigger/handleRefresh.