### PR TITLE
Fix two bugs: GroupMe silent non-response and ESPN roster fetch retur…

### DIFF
--- a/internal/espn/espn.go
+++ b/internal/espn/espn.go
@@ -98,9 +98,14 @@ func (s *ESPNService) fetchTeamRoster(ctx context.Context, teamID int) (*TeamWit
 
 	twr := &TeamWithRoster{Team: rr.Team}
 	for _, pos := range rr.Athletes {
-		for _, athlete := range pos.Items {
-			athlete.Position = pos.Position
-			twr.Roster = append(twr.Roster, athlete)
+		for _, ra := range pos.Items {
+			twr.Roster = append(twr.Roster, Athlete{
+				AthleteID:   ra.AthleteID,
+				FirstName:   ra.FirstName,
+				LastName:    ra.LastName,
+				DisplayName: ra.DisplayName,
+				Position:    ra.Position.Abbreviation,
+			})
 		}
 	}
 

--- a/internal/espn/espn_struct.go
+++ b/internal/espn/espn_struct.go
@@ -1,10 +1,30 @@
 package espn
 
+// rawAthletePosition matches ESPN's nested position object on each athlete.
+type rawAthletePosition struct {
+	Abbreviation string `json:"abbreviation"`
+}
+
+// rawAthlete is used only for decoding the ESPN API response.
+// ESPN returns each athlete's position as an object, not a string.
+type rawAthlete struct {
+	AthleteID   string             `json:"id"`
+	FirstName   string             `json:"firstName"`
+	LastName    string             `json:"lastName"`
+	DisplayName string             `json:"displayName"`
+	Position    rawAthletePosition `json:"position"`
+}
+
+type rawPosition struct {
+	Position string       `json:"position"`
+	Items    []rawAthlete `json:"items"`
+}
+
 type RosterResponse struct {
-	Timestamp string     `json:"timestamp"`
-	Status    string     `json:"status"`
-	Athletes  []Position `json:"athletes"`
-	Team      Team       `json:"team"`
+	Timestamp string        `json:"timestamp"`
+	Status    string        `json:"status"`
+	Athletes  []rawPosition `json:"athletes"`
+	Team      Team          `json:"team"`
 }
 
 type Position struct {
@@ -17,7 +37,7 @@ type Athlete struct {
 	FirstName   string `json:"firstName"`
 	LastName    string `json:"lastName"`
 	DisplayName string `json:"displayName"`
-	Position    string `json:"position"`
+	Position    string
 }
 
 type Team struct {

--- a/internal/espn/espn_test.go
+++ b/internal/espn/espn_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func rosterJSON(teamID, teamName string, athletes []Athlete) string {
-	positions := []Position{{Position: "QB", Items: athletes}}
+func rosterJSON(teamID, teamName string, athletes []rawAthlete) string {
+	positions := []rawPosition{{Position: "offense", Items: athletes}}
 	resp := RosterResponse{
 		Team: Team{
 			TeamID:          teamID,
@@ -34,12 +34,11 @@ func TestFetchAllTeamRosters_ReturnsValidTeams(t *testing.T) {
 		fmt.Sscanf(r.URL.Path, "/%d", &teamID)
 		if teamID == 1 {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, rosterJSON("1", "Kansas City Chiefs", []Athlete{
-				{AthleteID: "1", DisplayName: "Patrick Mahomes", Position: "QB"},
+			fmt.Fprint(w, rosterJSON("1", "Kansas City Chiefs", []rawAthlete{
+				{AthleteID: "1", DisplayName: "Patrick Mahomes", Position: rawAthletePosition{Abbreviation: "QB"}},
 			}))
 			return
 		}
-		// All other team IDs return 404 (simulates non-existent teams).
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -91,7 +90,7 @@ func TestFetchAllTeamRosters_AllFailReturnsError(t *testing.T) {
 }
 
 func TestFetchAllTeamRosters_PositionTaggedOnAthletes(t *testing.T) {
-	// Verifies that the position from the Position group is set on each Athlete.
+	// Verifies that each athlete's individual position abbreviation is preserved.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var id int
 		fmt.Sscanf(r.URL.Path, "/%d", &id)
@@ -101,9 +100,13 @@ func TestFetchAllTeamRosters_PositionTaggedOnAthletes(t *testing.T) {
 		}
 		resp := RosterResponse{
 			Team: Team{TeamID: "1", Name: "Chiefs"},
-			Athletes: []Position{
-				{Position: "QB", Items: []Athlete{{AthleteID: "10", DisplayName: "Mahomes"}}},
-				{Position: "WR", Items: []Athlete{{AthleteID: "11", DisplayName: "Rice"}}},
+			Athletes: []rawPosition{
+				{Position: "offense", Items: []rawAthlete{
+					{AthleteID: "10", DisplayName: "Mahomes", Position: rawAthletePosition{Abbreviation: "QB"}},
+				}},
+				{Position: "offense", Items: []rawAthlete{
+					{AthleteID: "11", DisplayName: "Rice", Position: rawAthletePosition{Abbreviation: "WR"}},
+				}},
 			},
 		}
 		b, _ := json.Marshal(resp)

--- a/internal/handlers/message_handler/message.go
+++ b/internal/handlers/message_handler/message.go
@@ -15,8 +15,9 @@ func Handle(message groupme.Message, oai *open_ai.OpenAIService, gms *groupme.Gr
 		return "", err
 	}
 
+	shouldRespond := strings.Contains(strings.ToLower(message.Text), "hey crowfather")
 	message.Text = cleanMessage(message.Text)
-	resp, err := processMessage(message, oai, assistantID)
+	resp, err := processMessage(message, oai, assistantID, shouldRespond)
 
 	if err != nil || resp == "" {
 		return "", err
@@ -33,16 +34,14 @@ func Handle(message groupme.Message, oai *open_ai.OpenAIService, gms *groupme.Gr
 	return "", nil
 }
 
-func processMessage(message groupme.Message, oai *open_ai.OpenAIService, assistantID string) (string, error) {
-	lowercasedMessage := strings.ToLower(message.Text)
-
+func processMessage(message groupme.Message, oai *open_ai.OpenAIService, assistantID string, shouldRespond bool) (string, error) {
 	msg, err := addMessageToThread(message, oai)
 
 	if err != nil {
 		return "", err
 	}
 
-	if strings.Contains(lowercasedMessage, "hey crowfather") {
+	if shouldRespond {
 		return respondToThread(msg, oai, assistantID)
 	}
 	return "", nil


### PR DESCRIPTION
…ning 1 team

Fix 1: GroupMe message handler silently drops responses (message.go) The trigger check (strings.Contains "hey crowfather") ran against the already- cleaned message text, after cleanMessage() had stripped the "hey crowfather" prefix. The check was always false, so respondToThread() was never called. Messages were being added to the OpenAI thread but no run was ever created. Fix: capture shouldRespond from the original text before cleaning, pass it as a bool to processMessage().

Fix 2: ESPN FetchAllTeamRosters returning only 1 team (espn_struct.go, espn.go) ESPN's API returns each athlete's position as a JSON object {"name": "Quarterback", "abbreviation": "QB"} but Athlete.Position was typed as string. json.Decode returned an error for every team that had athletes, causing fetchTeamRoster to return nil,err and the team to be silently skipped. Only teams with empty rosters decoded successfully (1 team). Fix: introduce unexported rawAthlete/rawPosition/rawAthletePosition structs for decoding the ESPN response. Map to the public Athlete struct after decode, using Position.Abbreviation for the real position ("QB", "WR", etc.) instead of the group label ("offense", "defense").