### PR TITLE
Fix vector store files uploading as anonymous_file with failed status

### DIFF
--- a/internal/open_ai/vector_store.go
+++ b/internal/open_ai/vector_store.go
@@ -20,6 +20,16 @@ func (oai *OpenAIService) CreateVectorStore(ctx context.Context, name string) (s
 	return vs.ID, nil
 }
 
+// namedReader wraps a bytes.Reader with a filename so the OpenAI SDK
+// multipart encoder picks it up via the Name() interface instead of
+// falling back to "anonymous_file".
+type namedReader struct {
+	*bytes.Reader
+	name string
+}
+
+func (n namedReader) Name() string { return n.name }
+
 // UploadFilesToVectorStore uploads the provided documents to a vector store in a
 // single batch and polls until all files are processed.
 // docs is a map of filename → file content (Markdown bytes).
@@ -31,9 +41,9 @@ func (oai *OpenAIService) UploadFilesToVectorStore(ctx context.Context, vsID str
 	client := openai.NewClient(oai.Options...)
 
 	fileParams := make([]openai.FileNewParams, 0, len(docs))
-	for _, content := range docs {
+	for name, content := range docs {
 		fileParams = append(fileParams, openai.FileNewParams{
-			File:    bytes.NewReader(content),
+			File:    namedReader{bytes.NewReader(content), name},
 			Purpose: openai.FilePurposeAssistants,
 		})
 	}


### PR DESCRIPTION
The OpenAI SDK's multipart encoder checks if the io.Reader passed to FileNewParams.File implements Filename() or Name() to determine the filename for the multipart form field. bytes.NewReader satisfies neither interface, so the SDK fell back to the hardcoded default "anonymous_file", causing all uploads to fail.

Two bugs combined to produce this:
1. The map iteration used _ for the key, discarding the filename entirely.
2. bytes.NewReader carries no filename metadata.

Fix: introduce a namedReader struct that embeds *bytes.Reader and implements Name() string, returning the filename from the docs map key. The SDK encoder picks this up via the Name() interface and uses it as the multipart filename.